### PR TITLE
[BE] [#67] JWT 관련 필터와 getEmail 수정

### DIFF
--- a/back-end/src/main/java/com/techie/backend/global/security/JWTFilter.java
+++ b/back-end/src/main/java/com/techie/backend/global/security/JWTFilter.java
@@ -21,6 +21,12 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String authorization = request.getHeader("Authorization");
+        String path = request.getRequestURI();
+
+        if ("/login".equals(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             System.out.println("token null");

--- a/back-end/src/main/java/com/techie/backend/global/security/JWTUtil.java
+++ b/back-end/src/main/java/com/techie/backend/global/security/JWTUtil.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @Component
 public class JWTUtil {
 
-    private SecretKey secretKey;
+    private final SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.security.jwt.secret}") String secret) {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
@@ -32,7 +32,7 @@ public class JWTUtil {
 
     public String createJwt(String email, String role, Long expiredMs) {
         return Jwts.builder()
-                .claim("username", email)
+                .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))


### PR DESCRIPTION
## 🔗 관련 이슈
#67 

## 📝 개요
컨트롤러 단에서 @AuthenticationPrincipal에 의해 주입된 userDetails의 email이 null인 현상을 해결합니다.

## 🛠️ 작업 내용
AuthenticationPrincipalArgumentResolver에서 
`this.securityContextHolderStrategy.getContext().getAuthentication()`
으로 받아온 Authentication의 principal의 email값이 null인 것을 발견하였습니다. 

그 이유는 `JWTFilter`의 `doFilterInternal()`에서
`String email = jwtUtil.getEmail(token);`의 값이 null인 것이 원인이었습니다.
JWTUtil 클래스에서
```
public String getEmail(String token) {
        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
    }
```
getEmail()은 "email" 이름의 필드값을 반환하지만,
```
public String createJwt(String email, String role, Long expiredMs) {
        return Jwts.builder()
                .claim("username", email) // username -> email
                .claim("role", role)
                .issuedAt(new Date(System.currentTimeMillis()))
                .expiration(new Date(System.currentTimeMillis() + expiredMs))
                .signWith(secretKey)
                .compact();
    }
```
JWT를 만들때는 email 값을 "username" 이름의 필드로 저장합니다.
따라서 `.claim("email", email)`로 수정하니 정상 작동하였습니다.

그리고 자잘한 수정 사항으로,
수정 전에는 `JWTFilter`의 `doFilterInternal()`에서 아래와 같이 요청 헤더의 Authorization 값이 null 이라면
token null을 출력하고, 다음 필터로 넘어가게 됩니다.
```
String authorization = request.getHeader("Authorization");

if (authorization == null || !authorization.startsWith("Bearer ")) {
    System.out.println("token null");
    filterChain.doFilter(request, response);
    return;
}
```
하지만 로그인을 할 때는 요청 헤더에 Authorization이 없기 때문에, 로그인 요청인지를 확인하고 
맞다면 바로 JWTFilter에서 바로 다음 필터로 넘어가게끔했습니다.
```
String path = request.getRequestURI();

if ("/login".equals(path)) {
            filterChain.doFilter(request, response);
            return;
        }
```

- [x] 버그 수정


## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).