### PR TITLE
[BE] [#96] 메모 페이징 기능 구현

### DIFF
--- a/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
+++ b/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
@@ -48,7 +48,7 @@ public class MemoController {
 
     @PutMapping("/{id}")
     public ResponseEntity<MemoResponse> updateMemo(@PathVariable Long id,
-                                                   @RequestBody MemoUpdateRequest updateRequest,
+                                                   @RequestBody MemoRequest.Update updateRequest,
                                                    @AuthenticationPrincipal UserDetailsCustom userDetails) throws AccessDeniedException {
         return memoService.updateMemo(userDetails.getUsername(), id, updateRequest);
     }

--- a/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
+++ b/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
@@ -6,6 +6,9 @@ import com.techie.backend.memo.dto.MemoResponse;
 import com.techie.backend.memo.dto.MemoUpdateRequest;
 import com.techie.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -37,9 +40,10 @@ public class MemoController {
     }
 
     @GetMapping("/byVideo")
-    public ResponseEntity<List<MemoResponse>> getAllMemosByVideo(@RequestParam String vId,
-                                                                 @AuthenticationPrincipal UserDetailsCustom userDetails) {
-        return memoService.getAllMemosByVideoId(userDetails.getUsername(), vId);
+    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideo(@RequestParam String vId,
+                                                                  @AuthenticationPrincipal UserDetailsCustom userDetails,
+                                                                  Pageable pageable) {
+        return memoService.getAllMemosByVideoId(userDetails.getUsername(), vId, pageable);
     }
 
     @PutMapping("/{id}")

--- a/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
+++ b/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
@@ -3,18 +3,15 @@ package com.techie.backend.memo.controller;
 import com.techie.backend.global.security.UserDetailsCustom;
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
-import com.techie.backend.memo.dto.MemoUpdateRequest;
 import com.techie.backend.memo.service.MemoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,8 +32,9 @@ public class MemoController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<MemoResponse>> getAllMemos(@AuthenticationPrincipal UserDetailsCustom userDetails) {
-        return memoService.getMemoList(userDetails.getUsername());
+    public ResponseEntity<Slice<MemoResponse>> getAllMemos(@AuthenticationPrincipal UserDetailsCustom userDetails,
+                                                          Pageable pageable) {
+        return memoService.getMemoList(userDetails.getUsername(), pageable);
     }
 
     @GetMapping("/byVideo")

--- a/back-end/src/main/java/com/techie/backend/memo/dto/MemoRequest.java
+++ b/back-end/src/main/java/com/techie/backend/memo/dto/MemoRequest.java
@@ -9,4 +9,10 @@ public class MemoRequest {
     private String content;
     private String noteTime;
     private String videoId;
+
+    @Data
+    public static class Update {
+        private String title;
+        private String content;
+    }
 }

--- a/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
+++ b/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
@@ -1,11 +1,14 @@
 package com.techie.backend.memo.dto;
 
 import com.techie.backend.memo.domain.Memo;
+import com.techie.backend.video.domain.Video;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class MemoResponse {
     private Long id;
     private String title;
@@ -13,11 +16,13 @@ public class MemoResponse {
     private String noteTime;
     private String videoId;
 
-    public MemoResponse(Memo memo) {
-        this.id = memo.getId();
-        this.title = memo.getTitle();
-        this.content = memo.getContent();
-        this.noteTime = memo.getNoteTime();
-        this.videoId = memo.getVideo().getVideoId();
+    public static MemoResponse MemoToResponse(Memo memo, Video video) {
+        return new MemoResponse(
+                memo.getId(),
+                memo.getTitle() != null ? memo.getTitle() : null,
+                memo.getContent(),
+                memo.getNoteTime() != null ? memo.getNoteTime() : null,
+                video != null ? video.getVideoId() : null
+        );
     }
 }

--- a/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
+++ b/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
@@ -1,8 +1,11 @@
 package com.techie.backend.memo.dto;
 
+import com.techie.backend.memo.domain.Memo;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class MemoResponse {
     private Long id;
     private String title;
@@ -10,4 +13,11 @@ public class MemoResponse {
     private String noteTime;
     private String videoId;
 
+    public MemoResponse(Memo memo) {
+        this.id = memo.getId();
+        this.title = memo.getTitle();
+        this.content = memo.getContent();
+        this.noteTime = memo.getNoteTime();
+        this.videoId = memo.getVideo().getVideoId();
+    }
 }

--- a/back-end/src/main/java/com/techie/backend/memo/dto/MemoUpdateRequest.java
+++ b/back-end/src/main/java/com/techie/backend/memo/dto/MemoUpdateRequest.java
@@ -1,9 +1,0 @@
-package com.techie.backend.memo.dto;
-
-import lombok.Data;
-
-@Data
-public class MemoUpdateRequest {
-    private String title;
-    private String content;
-}

--- a/back-end/src/main/java/com/techie/backend/memo/repository/MemoRepository.java
+++ b/back-end/src/main/java/com/techie/backend/memo/repository/MemoRepository.java
@@ -3,12 +3,14 @@ package com.techie.backend.memo.repository;
 import com.techie.backend.memo.domain.Memo;
 import com.techie.backend.user.domain.User;
 import com.techie.backend.video.domain.Video;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     List<Memo> findByUser(User user);
-    List<Memo> findByUserAndVideo(User user, Video video);
+    // List<Memo> findByUserAndVideo(User user, Video video);
+    Slice<Memo> findByUserAndVideo(User user, Video video, Pageable pageable);
 }

--- a/back-end/src/main/java/com/techie/backend/memo/repository/MemoRepository.java
+++ b/back-end/src/main/java/com/techie/backend/memo/repository/MemoRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     List<Memo> findByUser(User user);
-    // List<Memo> findByUserAndVideo(User user, Video video);
     Slice<Memo> findByUserAndVideo(User user, Video video, Pageable pageable);
+    Slice<Memo> findByUser(User user, Pageable pageable);
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
@@ -3,6 +3,8 @@ package com.techie.backend.memo.service;
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
 import com.techie.backend.memo.dto.MemoUpdateRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 
 import java.nio.file.AccessDeniedException;
@@ -13,8 +15,7 @@ public interface MemoService {
     public ResponseEntity<List<MemoResponse>> getMemoList(String username);
     public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException;
 
-    // -- 영상 별 메모 조회
-    ResponseEntity<List<MemoResponse>> getAllMemosByVideoId(String username, String videoId);
+    ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(String username, String videoId, Pageable pageable);
     public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoUpdateRequest updateRequest) throws AccessDeniedException;
     public ResponseEntity<String> deleteMemo(String username, Long id) throws AccessDeniedException;
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
@@ -2,17 +2,15 @@ package com.techie.backend.memo.service;
 
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
-import com.techie.backend.memo.dto.MemoUpdateRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 
 import java.nio.file.AccessDeniedException;
-import java.util.List;
 
 public interface MemoService {
     public ResponseEntity<MemoResponse> createMemo(MemoRequest memoRequest, String username);
-    public ResponseEntity<List<MemoResponse>> getMemoList(String username);
+    public ResponseEntity<Slice<MemoResponse>> getMemoList(String username, Pageable pageable);
     public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException;
 
     ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(String username, String videoId, Pageable pageable);

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
@@ -16,6 +16,6 @@ public interface MemoService {
     public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException;
 
     ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(String username, String videoId, Pageable pageable);
-    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoUpdateRequest updateRequest) throws AccessDeniedException;
+    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException;
     public ResponseEntity<String> deleteMemo(String username, Long id) throws AccessDeniedException;
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -4,7 +4,6 @@ import com.techie.backend.global.exception.memo.EmptyContentException;
 import com.techie.backend.memo.domain.Memo;
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
-import com.techie.backend.memo.dto.MemoUpdateRequest;
 import com.techie.backend.memo.repository.MemoRepository;
 import com.techie.backend.user.domain.User;
 import com.techie.backend.user.repository.UserRepository;
@@ -37,7 +36,7 @@ public class MemoServiceImpl implements MemoService {
     // -- 메모 생성 --
     @Override
     public ResponseEntity<MemoResponse> createMemo(MemoRequest request, String username) {
-        if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+        if (request.getContent() == null || request.getContent().isBlank()) {
             throw new EmptyContentException();
         }
 
@@ -109,7 +108,7 @@ public class MemoServiceImpl implements MemoService {
 
     // -- 메모 수정 --
     @Override
-    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoUpdateRequest updateRequest) throws AccessDeniedException {
+    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException {
         Memo memo = memoRepository.findById(id)
                 .orElseThrow(()->new EntityNotFoundException("메모를 찾을 수 없습니다."));
 
@@ -119,6 +118,10 @@ public class MemoServiceImpl implements MemoService {
         }
 
         memo.changeTitle(updateRequest.getTitle());
+        String content = updateRequest.getContent();
+        if (content == null || content.isBlank()) {
+            throw new EmptyContentException();
+        }
         memo.changeContent(updateRequest.getContent());
         memoRepository.save(memo);
 

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -61,12 +61,13 @@ public class MemoServiceImpl implements MemoService {
     @Override
     public ResponseEntity<Slice<MemoResponse>> getMemoList(String username, Pageable pageable) {
         User user = userRepository.findByEmail(username);
-        Slice<MemoResponse> memoSlice = memoRepository.findByUser(user, pageable).map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
+        Slice<MemoResponse> memoSlice = memoRepository.findByUser(user, pageable)
+                                        .map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
 
-        // 현재 사용자가 작성한 메모가 없을 경우
         if(memoSlice.isEmpty()) {
             throw new EntityNotFoundException("현재 사용자가 작성한 메모가 없거나 모두 표시했습니다.");
         }
+
         return ResponseEntity.ok(memoSlice);
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
#96 

## 📝 개요
프론트로 반환하는 메모 JSON 응답에 페이징 처리를 적용했습니다.

## 🛠️ 작업 내용
1. **메모 전체 목록 조회**, **메모 영상별 조회** 기능에 페이징을 적용하였습니다.
2. MemoRequest와 MemoUpdateRequest로 나누어져있던 dto를 nested 구조로 변경하였습니다.
3. MemoResponse에 Memo에서 MemoResponse로 변환하는 정적 메소드를 추가하였습니다.

</br>

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).