### PR TITLE
[BE] [#116] 메모가 없을 시 로직 수정

### DIFF
--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -64,10 +64,6 @@ public class MemoServiceImpl implements MemoService {
         Slice<MemoResponse> memoSlice = memoRepository.findByUser(user, pageable)
                                         .map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
 
-        if(memoSlice.isEmpty()) {
-            throw new EntityNotFoundException("현재 사용자가 작성한 메모가 없거나 모두 표시했습니다.");
-        }
-
         return ResponseEntity.ok(memoSlice);
     }
 
@@ -95,9 +91,7 @@ public class MemoServiceImpl implements MemoService {
 
         Slice<MemoResponse> memoSlice = memoRepository.findByUserAndVideo(user, video, pageable)
                                                         .map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
-        if (memoSlice.isEmpty()) {
-            throw new EntityNotFoundException("해당 영상에 작성한 메모가 없거나 모두 표시했습니다.");
-        }
+
         return ResponseEntity.ok(memoSlice);
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
#116 
## 📝 개요
메모가 없을 시 예외가 아닌 "empty" : true를 반환하도록 수정합니다.

## 🛠️ 작업 내용
`getMemoList`와 `getAllMemosByVideoId` 에서 기존의 예외를 발생시키는 코드를 삭제
```java
// 삭제
if (memoSlice.isEmpty()) {
    throw new EntityNotFoundException("메시지");
}
```
대신 응답 JSON에서 "empty" 값이 true 라면 그에 따른 화면을 보여주도록 협의하였습니다.


- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).