### PR TITLE
[BE] [#130] 영상 요청 방식 변경

### DIFF
--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -20,7 +20,7 @@ public class VideoController {
     private final VideoService videoService;
 
     @GetMapping("/{category}")
-    public Slice<VideoResponse> listCategoryVideo(@PathVariable String category, Pageable pageable) throws JsonProcessingException {
+    public Slice<VideoResponse> listCategoryVideo(@PathVariable Category category, Pageable pageable) throws JsonProcessingException {
         return videoService.fetchVideosByCategory(category, pageable);
     }
 

--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -24,8 +24,8 @@ public class VideoController {
         return videoService.fetchVideosByCategory(category, pageable);
     }
 
-    @GetMapping
-    public Slice<VideoResponse> searchVideo(@RequestParam String query, Pageable pageable) throws JsonProcessingException {
-        return videoService.fetchVideosByQuery(query, pageable);
-    }
+//    @GetMapping
+//    public Slice<VideoResponse> searchVideo(@RequestParam String query, Pageable pageable) throws JsonProcessingException {
+//        return videoService.fetchVideosByQuery(query, pageable);
+//    }
 }

--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -24,8 +24,10 @@ public class VideoController {
         return videoService.fetchVideosByCategory(category, pageable);
     }
 
-//    @GetMapping
-//    public Slice<VideoResponse> searchVideo(@RequestParam String query, Pageable pageable) throws JsonProcessingException {
-//        return videoService.fetchVideosByQuery(query, pageable);
-//    }
+    @GetMapping
+    public Slice<VideoResponse> searchVideo(@RequestParam String query,
+                                            @RequestParam Category category,
+                                            Pageable pageable) throws JsonProcessingException {
+        return videoService.fetchVideosByQuery(query, category, pageable);
+    }
 }

--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -20,7 +20,7 @@ public class VideoController {
     private final VideoService videoService;
 
     @GetMapping("/{category}")
-    public Slice<VideoResponse> listCategoryVideo(@PathVariable Category category, Pageable pageable) throws JsonProcessingException {
+    public Slice<VideoResponse> listCategoryVideo(@PathVariable String category, Pageable pageable) throws JsonProcessingException {
         return videoService.fetchVideosByCategory(category, pageable);
     }
 

--- a/back-end/src/main/java/com/techie/backend/video/domain/Category.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Category.java
@@ -8,11 +8,11 @@ public enum Category {
     GAME("PLnXuZ8uq_pEy3iNLMBzuTZiaOdag3jD2j"),
     BACK("PLnXuZ8uq_pEwpUqyIHT2nadcahS9140iN"),
     MOBILE("PLnXuZ8uq_pExCp6JiZR86JBgO1MQOHd1s"),
-    FRONT("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), // 수정
+    FRONT("PLnXuZ8uq_pEzL0Wpx6htivfunZeLUvVAJ"),
     DATA("PLnXuZ8uq_pEw-n-gp3N-wbgczXLGOGLKM"),
-    AI("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), //수정
+    AI("PLnXuZ8uq_pEwa3_LvdFOrh_8cWLcjlpQY"),
     SEC("PLnXuZ8uq_pEyLc2Gpe2MEhUopshbNbqvS"),
-    CS("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), //수정
+    CS("PLnXuZ8uq_pEwiKyFhXMp45e8kahu_U2K8"),
     CLOUD("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4");
 
     private final String playlistId;

--- a/back-end/src/main/java/com/techie/backend/video/domain/Category.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Category.java
@@ -1,14 +1,23 @@
 package com.techie.backend.video.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum Category {
-    LANG,
-    GAME,
-    BACK,
-    MOBILE,
-    FRONT,
-    DATA,
-    AI,
-    SEC,
-    CS,
-    CLOUD
+    LANG("PLnXuZ8uq_pEzukhPLqUyCvTttrGLHYdX-"),
+    GAME("PLnXuZ8uq_pEy3iNLMBzuTZiaOdag3jD2j"),
+    BACK("PLnXuZ8uq_pEwpUqyIHT2nadcahS9140iN"),
+    MOBILE("PLnXuZ8uq_pExCp6JiZR86JBgO1MQOHd1s"),
+    FRONT("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), // 수정
+    DATA("PLnXuZ8uq_pEw-n-gp3N-wbgczXLGOGLKM"),
+    AI("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), //수정
+    SEC("PLnXuZ8uq_pEyLc2Gpe2MEhUopshbNbqvS"),
+    CS("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4"), //수정
+    CLOUD("PLnXuZ8uq_pEwA3zIEs8VrMZnuDwPbiVV4");
+
+    private final String playlistId;
+
+    Category(String playlistId) {
+        this.playlistId = playlistId;
+    }
 }

--- a/back-end/src/main/java/com/techie/backend/video/domain/Video.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Video.java
@@ -20,9 +20,8 @@ public class Video {
     @Column(nullable = false)
     private String title;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Category category;
+    private String category;
 
     @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaylistVideo> playlistVideos = new ArrayList<>();

--- a/back-end/src/main/java/com/techie/backend/video/domain/Video.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Video.java
@@ -20,8 +20,9 @@ public class Video {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
-    private String category;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private Category category;
 
     @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaylistVideo> playlistVideos = new ArrayList<>();

--- a/back-end/src/main/java/com/techie/backend/video/dto/VideoResponse.java
+++ b/back-end/src/main/java/com/techie/backend/video/dto/VideoResponse.java
@@ -13,6 +13,7 @@ public class VideoResponse {
     private String description;
     private String channelTitle;
     private LocalDateTime publishedAt;
+    private String duration;
     private Map<String, Thumbnail> thumbnails;
 
     @Data
@@ -21,5 +22,6 @@ public class VideoResponse {
         private int width;
         private int height;
     }
+
 }
 

--- a/back-end/src/main/java/com/techie/backend/video/dto/VideoResponse.java
+++ b/back-end/src/main/java/com/techie/backend/video/dto/VideoResponse.java
@@ -13,7 +13,6 @@ public class VideoResponse {
     private String description;
     private String channelTitle;
     private LocalDateTime publishedAt;
-    private String duration;
     private Map<String, Thumbnail> thumbnails;
 
     @Data

--- a/back-end/src/main/java/com/techie/backend/video/repository/VideoRepository.java
+++ b/back-end/src/main/java/com/techie/backend/video/repository/VideoRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface VideoRepository extends JpaRepository<Video, String> {
-    List<Video> findByCategory(String category);
+    List<Video> findByCategory(Category category);
     List<Video> findByTitleContaining(String keyword);
     Optional<Video> findByVideoId(String videoId);
 }

--- a/back-end/src/main/java/com/techie/backend/video/repository/VideoRepository.java
+++ b/back-end/src/main/java/com/techie/backend/video/repository/VideoRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface VideoRepository extends JpaRepository<Video, String> {
-    List<Video> findByCategory(Category category);
+    List<Video> findByCategory(String category);
     List<Video> findByTitleContaining(String keyword);
     Optional<Video> findByVideoId(String videoId);
 }

--- a/back-end/src/main/java/com/techie/backend/video/service/VideoService.java
+++ b/back-end/src/main/java/com/techie/backend/video/service/VideoService.java
@@ -37,7 +37,7 @@ public class VideoService {
     private final VideoRepository videoRepository;
     private final ObjectMapper objectMapper;
 
-    public Slice<VideoResponse> fetchVideosByCategory(Category category, Pageable pageable) {
+    public Slice<VideoResponse> fetchVideosByCategory(String category, Pageable pageable) {
         String videoIds = getVideoIds(videoRepository.findByCategory(category));
         ResponseEntity<String> response = getYoutubeResponse(videoIds);
         return convertJsonToVideoDTO(response.getBody(), pageable);

--- a/back-end/src/main/java/com/techie/backend/video/service/VideoService.java
+++ b/back-end/src/main/java/com/techie/backend/video/service/VideoService.java
@@ -37,9 +37,8 @@ public class VideoService {
     private final VideoRepository videoRepository;
     private final ObjectMapper objectMapper;
 
-    public Slice<VideoResponse> fetchVideosByCategory(String category, Pageable pageable) {
-        String videoIds = getVideoIds(videoRepository.findByCategory(category));
-        ResponseEntity<String> response = getYoutubeResponse(videoIds);
+    public Slice<VideoResponse> fetchVideosByCategory(Category category, Pageable pageable) {
+        ResponseEntity<String> response = getYoutubeResponse(category.getPlaylistId());
         return convertJsonToVideoDTO(response.getBody(), pageable);
     }
 
@@ -53,10 +52,10 @@ public class VideoService {
         return findVideos.stream().map(Video::getVideoId).collect(Collectors.joining(","));
     }
 
-    private ResponseEntity<String> getYoutubeResponse(String videoIds) {
-        String uri = UriComponentsBuilder.fromHttpUrl("https://www.googleapis.com/youtube/v3/videos")
+    private ResponseEntity<String> getYoutubeResponse(String playlistId) {
+        String uri = UriComponentsBuilder.fromHttpUrl("https://www.googleapis.com/youtube/v3/playlistItems")
                 .queryParam("part", "snippet,contentDetails")
-                .queryParam("id", videoIds)
+                .queryParam("playlistId", playlistId)
                 .queryParam("key", apiKey)
                 .build()
                 .toUriString();


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 관련된 이슈 번호가 있으면 작성해주세요. -->
#130 

## 📝 개요
youtube api 로의 영상 요청 방식을 변경하려고 합니다.
<br/>
기존 방식: DB에 저장되어있는 영상 id 값을 불러와 유튜브 api 요청의 파라미터로 넘김
변경 방식: 유튜브 재생목록 id를 유튜브 api 요청의 파라미터로 넘김. 응답은 해당 재생목록에 포함된 영상들
기대효과: 영상 DB를 수작업으로 업데이트 해줘야하는 부담이 줄어듦

## 🛠️ 작업 내용
1. `Category`에 재생목록 값을 추가
2. 검색 기능에서 `Category`를 쿼리 파라미터로 받도록 수정
3. youtube api 요청 url을 만드는 헬퍼 메소드 추가
<br/>
유튜브 영상들을 받아오는 로직은 다음과 같습니다. 

<br/>

1. [재생목록으로 영상을 가져오는 방식]으로 요청을 보냄
2. 응답 영상들의 id 값을 뽑아냄
3. 2번에서 얻은 id 값을 이용해 [영상 Id로 불러오는 방식]으로 다시 요청
4. 영상 길이가 포함되어있는 응답을 받음

<br/>

위와 같이 요청을 두 번 보내는 이유는 영상 길이 `duration`을 얻기 위해서입니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).