### PR TITLE
[BE] [#132] 모든 카테고리 영상 조회해오기

### DIFF
--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -30,4 +30,9 @@ public class VideoController {
                                             Pageable pageable) throws JsonProcessingException {
         return videoService.fetchVideosByQuery(query, category, pageable);
     }
+
+    @GetMapping("/list")
+    public Slice<VideoResponse> AllVideos (Pageable pageable) throws JsonProcessingException {
+        return videoService.fetchVideosFromAllCategories(pageable);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#132 

## 📝 개요
각 재생목록 영상을 조회하여, 그 결과를 합쳐 페이징하여 반환합니다.


## 🛠️ 작업 내용
`fetchVideosFromAllCategories` : 모든 재생목록을 순회하며 영상을 수집하고, 페이징하여 반환
`convertJsonToVideoDTOWithoutPaging`: 페이징 처리없이 모든 재생목록 영상을 List<VideoResponse>에 담아서 반환
`createSlice`: 파라미터로 받은 List<VideoResponse>를 페이징하여 반환

<br/>

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).