### PR TITLE
[FE] [#37] 마이페이지 정보 수정 백엔드 API 연동 

### DIFF
--- a/front-end/src/app/api/userApi.ts
+++ b/front-end/src/app/api/userApi.ts
@@ -43,14 +43,14 @@ export const updateUserNickname = async (nickname: string): Promise<string> => {
 
 // 비밀번호 업데이트
 export const updateUserPassword = async (
-  currentPassword: string,
+  oldPassword: string,
   newPassword: string,
 ): Promise<string> => {
   try {
     const token = Cookies.get('token');
     if (!token) throw new Error('로그인이 필요합니다.');
 
-    const payload = { password: currentPassword, newPassword };
+    const payload = { oldPassword, newPassword };
 
     await axios.put('/api/users/me', payload, {
       headers: { Authorization: `Bearer ${token}` },

--- a/front-end/src/app/api/userApi.ts
+++ b/front-end/src/app/api/userApi.ts
@@ -1,51 +1,84 @@
 import axios, { AxiosError } from 'axios';
 import Cookies from 'js-cookie';
 
-// 닉네임 및 비밀번호 업데이트 함수
-export const updateUserInfo = async (nickname?: string, password?: string): Promise<string> => {
+// 유저 정보 조회
+export const getUserInfo = async (): Promise<{ email: string; nickname: string }> => {
   try {
     const token = Cookies.get('token');
     if (!token) throw new Error('로그인이 필요합니다.');
 
-    // 요청 본문(payload) 구성
-    const payload: { nickname?: string; password?: string } = {};
-    if (nickname) payload.nickname = nickname;
-    if (password) payload.password = password;
-
-    // 서버에 요청 보내기
-    await axios.put('/api/users/me', payload, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+    const response = await axios.get('/api/users/me', {
+      headers: { Authorization: `Bearer ${token}` },
     });
 
-    // 알림 메시지 반환
-    if (nickname && password) {
-      return '닉네임과 비밀번호가 성공적으로 수정되었습니다.';
-    } else if (nickname) {
-      return '닉네임이 성공적으로 수정되었습니다.';
-    } else if (password) {
-      return '비밀번호가 성공적으로 수정되었습니다.';
-    }
-    return '정보가 성공적으로 수정되었습니다.';
+    return response.data;
   } catch (error) {
     if (error instanceof AxiosError) {
-      throw new Error(error.response?.data?.message || '정보 수정에 실패했습니다.');
+      throw new Error(error.response?.data?.message || '유저 정보를 가져오는데 실패했습니다.');
     }
     throw error;
   }
 };
 
-// 회원 탈퇴 함수
-export const deleteUser = async () => {
+// 닉네임 업데이트
+export const updateUserNickname = async (nickname: string): Promise<string> => {
   try {
     const token = Cookies.get('token');
     if (!token) throw new Error('로그인이 필요합니다.');
 
+    const payload = { nickname };
+
+    await axios.put('/api/users/me', payload, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    return '닉네임이 성공적으로 수정되었습니다.';
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      throw new Error(error.response?.data?.message || '닉네임 수정에 실패했습니다.');
+    }
+    throw error;
+  }
+};
+
+// 비밀번호 업데이트
+export const updateUserPassword = async (
+  currentPassword: string,
+  newPassword: string,
+): Promise<string> => {
+  try {
+    const token = Cookies.get('token');
+    if (!token) throw new Error('로그인이 필요합니다.');
+
+    const payload = { password: currentPassword, newPassword };
+
+    await axios.put('/api/users/me', payload, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    return '비밀번호가 성공적으로 수정되었습니다.';
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      if (error.response?.status === 401) {
+        throw new Error('기존 비밀번호를 다시 확인해주세요.');
+      }
+      throw new Error(error.response?.data?.message || '비밀번호 수정에 실패했습니다.');
+    }
+    throw error;
+  }
+};
+
+// 회원 탈퇴
+export const deleteUser = async (password: string): Promise<string> => {
+  try {
+    const token = Cookies.get('token');
+    if (!token) throw new Error('로그인이 필요합니다.');
+
+    const payload = { password };
+
     await axios.delete('/api/users/me', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
+      data: payload,
     });
 
     return '회원 탈퇴가 성공적으로 처리되었습니다.';

--- a/front-end/src/components/Header.tsx
+++ b/front-end/src/components/Header.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { FiSearch } from 'react-icons/fi';
@@ -16,30 +14,27 @@ const Header = () => {
 
   // 로그인 상태 확인 함수
   const checkLoginStatus = () => {
-    try {
-      const token = Cookies.get('token');
-      setIsLoggedIn(!!token);
-    } catch (error) {
-      console.error('Error accessing Cookies:', error);
-      setIsLoggedIn(false);
-    }
+    const token = Cookies.get('token');
+    setIsLoggedIn(!!token); // 토큰 유무에 따라 상태 업데이트
   };
 
   useEffect(() => {
-    checkLoginStatus();
-    window.addEventListener('loginStatusChanged', checkLoginStatus);
+    checkLoginStatus(); // 초기 로그인 상태 확인
+    const handleLoginStatusChange = () => checkLoginStatus();
+
+    window.addEventListener('loginStatusChanged', handleLoginStatusChange);
 
     return () => {
-      window.removeEventListener('loginStatusChanged', checkLoginStatus);
+      window.removeEventListener('loginStatusChanged', handleLoginStatusChange);
     };
   }, []);
 
   const handleLogout = () => {
-    Cookies.remove('token');
-    setIsLoggedIn(false);
-    window.dispatchEvent(new Event('loginStatusChanged'));
-    router.push('/');
-    dispatch(clearUserInfo());
+    Cookies.remove('token'); // 쿠키 제거
+    dispatch(clearUserInfo()); // Redux 상태 초기화
+    setIsLoggedIn(false); // 상태 업데이트
+    window.dispatchEvent(new Event('loginStatusChanged')); // 상태 변경 이벤트 트리거
+    router.push('/'); // 메인 페이지로 이동
   };
 
   const [searchQuery, setSearchQuery] = useState('');

--- a/front-end/src/components/mypage/UserInfoSection.tsx
+++ b/front-end/src/components/mypage/UserInfoSection.tsx
@@ -73,6 +73,7 @@ const UserInfoSection: React.FC = () => {
       alert('회원 탈퇴가 성공적으로 처리되었습니다.');
       Cookies.remove('token');
       dispatch(clearUserInfo());
+      window.dispatchEvent(new Event('loginStatusChanged'));
       router.push('/');
     } catch (error: unknown) {
       console.error('Error during account deletion:', error);

--- a/front-end/src/components/mypage/UserInfoSection.tsx
+++ b/front-end/src/components/mypage/UserInfoSection.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouter } from 'next/navigation';
-import { AxiosError } from 'axios';
-
-import { updateUserInfo, deleteUser } from '@/app/api/userApi';
+import { getUserInfo, updateUserNickname, updateUserPassword, deleteUser } from '@/app/api/userApi';
 import { RootState } from '@/redux/store';
 import { setUserInfo, clearUserInfo } from '@/redux/reducer';
 import Cookies from 'js-cookie';
@@ -16,44 +14,69 @@ const UserInfoSection: React.FC = () => {
   const router = useRouter();
 
   const [nickname, setNickname] = useState(userInfo?.nickname || '');
+  const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
+  const [deletePassword, setDeletePassword] = useState('');
 
-  // 유저 정보 수정
-  const handleUserInfoUpdate = async () => {
-    try {
-      await updateUserInfo(nickname, newPassword);
-      dispatch(setUserInfo({ ...userInfo, nickname })); // 상태 업데이트
-      alert('정보가 성공적으로 수정되었습니다.');
-    } catch (error: unknown) {
-      console.error('Error during user info update:', error);
-      if (error instanceof AxiosError && error.response) {
-        alert(`오류: ${error.response.data.message || '정보 수정에 실패했습니다.'}`);
-      } else if (error instanceof Error) {
-        alert(`오류: ${error.message}`);
-      } else {
-        alert('정보 수정에 실패했습니다.');
+  // 유저 정보 조회
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const userData = await getUserInfo();
+        dispatch(setUserInfo(userData));
+        setNickname(userData.nickname);
+      } catch (error) {
+        console.error('Error fetching user info:', error);
       }
+    };
+
+    fetchUserInfo();
+  }, [dispatch]);
+
+  // 닉네임 수정
+  const handleNicknameUpdate = async () => {
+    try {
+      await updateUserNickname(nickname);
+      dispatch(setUserInfo({ ...userInfo, nickname }));
+      alert('닉네임이 성공적으로 수정되었습니다.');
+    } catch (error: unknown) {
+      console.error('Error during nickname update:', error);
+      alert('닉네임 수정에 실패했습니다.');
+    }
+  };
+
+  // 비밀번호 수정
+  const handlePasswordUpdate = async () => {
+    if (!currentPassword || !newPassword) {
+      alert('기존 비밀번호와 새 비밀번호를 모두 입력해주세요.');
+      return;
+    }
+    try {
+      await updateUserPassword(currentPassword, newPassword);
+      alert('비밀번호가 성공적으로 수정되었습니다.');
+      setCurrentPassword('');
+      setNewPassword('');
+    } catch (error: unknown) {
+      console.error('Error during password update:', error);
+      alert('비밀번호 수정에 실패했습니다.');
     }
   };
 
   // 회원 탈퇴
   const handleDeleteUser = async () => {
+    if (!deletePassword) {
+      alert('탈퇴를 위해 비밀번호를 입력해주세요.');
+      return;
+    }
     try {
-      await deleteUser();
+      await deleteUser(deletePassword);
       alert('회원 탈퇴가 성공적으로 처리되었습니다.');
       Cookies.remove('token');
       dispatch(clearUserInfo());
-      window.dispatchEvent(new Event('loginStatusChanged'));
       router.push('/');
     } catch (error: unknown) {
       console.error('Error during account deletion:', error);
-      if (error instanceof AxiosError && error.response) {
-        alert(`오류: ${error.response.data.message || '회원 탈퇴에 실패했습니다.'}`);
-      } else if (error instanceof Error) {
-        alert(`오류: ${error.message}`);
-      } else {
-        alert('회원 탈퇴에 실패했습니다.');
-      }
+      alert('회원 탈퇴에 실패했습니다.');
     }
   };
 
@@ -67,10 +90,22 @@ const UserInfoSection: React.FC = () => {
           <strong>닉네임</strong>
           <div className="modify_cont">
             <input type="text" value={nickname} onChange={(e) => setNickname(e.target.value)} />
+            <button onClick={handleNicknameUpdate} className="nickname_modify_button">
+              닉네임 수정
+            </button>
           </div>
         </label>
       </div>
       <div className="password_cont">
+        <label>
+          <strong>기존 비밀번호</strong>
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder="기존 비밀번호 입력"
+          />
+        </label>
         <label>
           <strong>새 비밀번호</strong>
           <input
@@ -80,13 +115,24 @@ const UserInfoSection: React.FC = () => {
             placeholder="새 비밀번호 입력"
           />
         </label>
-        <button onClick={handleUserInfoUpdate} className="pwd_modify_button">
-          정보 수정
+        <button onClick={handlePasswordUpdate} className="pwd_modify_button">
+          비밀번호 수정
         </button>
       </div>
-      <button onClick={handleDeleteUser} className="secession_button">
-        회원 탈퇴
-      </button>
+      <div className="delete_account_cont">
+        <label>
+          <strong>회원 탈퇴 비밀번호</strong>
+          <input
+            type="password"
+            value={deletePassword}
+            onChange={(e) => setDeletePassword(e.target.value)}
+            placeholder="비밀번호 입력"
+          />
+        </label>
+        <button onClick={handleDeleteUser} className="secession_button">
+          회원 탈퇴
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 관련 이슈

#37 

## 📝 개요

- 마이페이지 정보 수정에서 버튼 1개로 구현되는 방식에서 닉네임 및 비밀번호, 회원탈퇴 버튼을 나뉘어 구현하는 방식으로 API 명세가 변경이 되어 그에 따른 수정사항을 반영하여 PR 생성합니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).