### PR TITLE
[BE] [#110] 회원 정보 수정 기능 개선 및 코드 개선

### DIFF
--- a/back-end/src/main/java/com/techie/backend/global/exception/ExceptionType.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/ExceptionType.java
@@ -13,12 +13,15 @@ public enum ExceptionType {
     EMPTY_FIELD(HttpStatus.BAD_REQUEST, "모든 필드를 입력해야 합니다."),
     PASSWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자리 이상이어야 합니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인 값이 일치하지 않습니다."),
+    NEW_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인 값이 일치하지 않습니다."),
     EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "내용이 비어있습니다."),
     PLAYLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트를 찾을 수 없습니다."),
     VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "비디오를 찾을 수 없습니다."),
     NO_CHANGES(HttpStatus.NOT_MODIFIED, "변경사항이 없습니다"),
     INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 값입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 올바르지 않습니다.");
+
     private final HttpStatus status;
     private final String message;
 

--- a/back-end/src/main/java/com/techie/backend/global/exception/GlobalExceptionHandler.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/GlobalExceptionHandler.java
@@ -91,4 +91,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleInvalidVideoIdException(InvalidVideoIdException ex) {
         return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(InvalidOldPasswordException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidOldPasswordException(InvalidOldPasswordException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NewPasswordMisMatchException.class)
+    public ResponseEntity<Map<String, Object>> handleNewPasswordMisMatchException(NewPasswordMisMatchException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/back-end/src/main/java/com/techie/backend/global/exception/user/InvalidOldPasswordException.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/user/InvalidOldPasswordException.java
@@ -1,0 +1,13 @@
+package com.techie.backend.global.exception.user;
+
+import com.techie.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class InvalidOldPasswordException extends RuntimeException {
+    private final ExceptionType exceptionType = ExceptionType.INVALID_OLD_PASSWORD;
+
+    public InvalidOldPasswordException() {
+        super(ExceptionType.INVALID_OLD_PASSWORD.getMessage());
+    }
+}

--- a/back-end/src/main/java/com/techie/backend/global/exception/user/NewPasswordMisMatchException.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/user/NewPasswordMisMatchException.java
@@ -1,0 +1,14 @@
+package com.techie.backend.global.exception.user;
+
+import com.techie.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class NewPasswordMisMatchException extends RuntimeException {
+    private final ExceptionType exceptionType;
+
+    public NewPasswordMisMatchException() {
+        super(ExceptionType.NEW_PASSWORD_MISMATCH.getMessage());
+        this.exceptionType = ExceptionType.NEW_PASSWORD_MISMATCH;
+    }
+}

--- a/back-end/src/main/java/com/techie/backend/global/security/JWTFilter.java
+++ b/back-end/src/main/java/com/techie/backend/global/security/JWTFilter.java
@@ -28,7 +28,6 @@ public class JWTFilter extends OncePerRequestFilter {
         }
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
-            System.out.println("token null");
             filterChain.doFilter(request, response);
             return;
         }

--- a/back-end/src/main/java/com/techie/backend/global/security/PathConfig.java
+++ b/back-end/src/main/java/com/techie/backend/global/security/PathConfig.java
@@ -1,0 +1,33 @@
+package com.techie.backend.global.security;
+
+import java.util.List;
+
+public class PathConfig {
+
+    // 접근 권한 : 로그인 여부 상관없음
+    public static final List<String> PERMIT_ALL_PATHS = List.of(
+            "/login",
+            "/",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/swagger-resources/**",
+            "/webjars/**",
+            "/static/**",
+            "/log.png",
+            "/api/users/**",
+            "/api/gpt/**",
+            "/api/videos/**"
+    );
+
+    // 접근 권한 : 인증된 사용자 (JWT 필요)
+    public static final List<String> AUTHENTICATED_PATHS = List.of(
+            "/api/users/me",
+            "/api/gpt/qna"
+    );
+
+    // 접근 권한 : 어드민 관리자 (ROLE_ADMIN 만 접근 가능)
+    public static final List<String> ADMIN_ONLY_PATHS = List.of(
+            "/api/users/admin"
+    );
+}

--- a/back-end/src/main/java/com/techie/backend/gpt/domain/Gpt.java
+++ b/back-end/src/main/java/com/techie/backend/gpt/domain/Gpt.java
@@ -15,6 +15,7 @@ public class Gpt {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @Lob
     @Column(nullable = false)
     private String request;
 

--- a/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
+++ b/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
@@ -35,14 +35,14 @@ public class MemoController {
     @GetMapping("/list")
     public ResponseEntity<Slice<MemoResponse>> getAllMemos(@AuthenticationPrincipal UserDetailsCustom userDetails,
                                                            @PageableDefault(size = 10) Pageable pageable) {
-        return memoService.getMemoList(userDetails.getUsername(), pageable);
+        return memoService.getMemoList(userDetails, userDetails.getUsername(), pageable);
     }
 
     @GetMapping("/byVideo")
     public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideo(@RequestParam String vId,
                                                                   @AuthenticationPrincipal UserDetailsCustom userDetails,
                                                                   @PageableDefault(size = 10) Pageable pageable) {
-        return memoService.getAllMemosByVideoId(userDetails.getUsername(), vId, pageable);
+        return memoService.getAllMemosByVideoId(userDetails, userDetails.getUsername(), vId, pageable);
     }
 
     @PutMapping("/{id}")

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
@@ -1,5 +1,6 @@
 package com.techie.backend.memo.service;
 
+import com.techie.backend.global.security.UserDetailsCustom;
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
 import org.springframework.data.domain.Pageable;
@@ -10,10 +11,10 @@ import java.nio.file.AccessDeniedException;
 
 public interface MemoService {
     public ResponseEntity<MemoResponse> createMemo(MemoRequest memoRequest, String username);
-    public ResponseEntity<Slice<MemoResponse>> getMemoList(String username, Pageable pageable);
+    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, String username, Pageable pageable);
     public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException;
 
-    ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(String username, String videoId, Pageable pageable);
+    ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String username, String videoId, Pageable pageable);
     public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException;
     public ResponseEntity<String> deleteMemo(String username, Long id) throws AccessDeniedException;
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -1,12 +1,14 @@
 package com.techie.backend.memo.service;
 
 import com.techie.backend.global.exception.memo.EmptyContentException;
+import com.techie.backend.global.security.UserDetailsCustom;
 import com.techie.backend.memo.domain.Memo;
 import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
 import com.techie.backend.memo.repository.MemoRepository;
 import com.techie.backend.user.domain.User;
 import com.techie.backend.user.repository.UserRepository;
+import com.techie.backend.user.service.UserService;
 import com.techie.backend.video.domain.Video;
 import com.techie.backend.video.repository.VideoRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -30,6 +32,7 @@ public class MemoServiceImpl implements MemoService {
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;
     private final VideoRepository videoRepository;
+    private final UserService userService;
     private final ModelMapper modelMapper;
 
     // -- 메모 생성 --
@@ -59,8 +62,8 @@ public class MemoServiceImpl implements MemoService {
 
     // --  메모 목록 조회 --
     @Override
-    public ResponseEntity<Slice<MemoResponse>> getMemoList(String username, Pageable pageable) {
-        User user = userRepository.findByEmail(username);
+    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, String username, Pageable pageable) {
+        User user = userService.getUserFromSecurityContext(userDetails);
         Slice<MemoResponse> memoSlice = memoRepository.findByUser(user, pageable)
                                         .map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
 
@@ -84,8 +87,8 @@ public class MemoServiceImpl implements MemoService {
 
     // -- 영상 별 메모 조회
     @Override
-    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(String username, String videoId, Pageable pageable) {
-        User user = userRepository.findByEmail(username);
+    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String username, String videoId, Pageable pageable) {
+        User user = userService.getUserFromSecurityContext(userDetails);
         Video video = videoRepository.findByVideoId(videoId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 영상이 없습니다."));
 
@@ -132,6 +135,4 @@ public class MemoServiceImpl implements MemoService {
         memoRepository.deleteById(memo.getId());
         return ResponseEntity.ok("메모가 정상적으로 삭제되었습니다.");
     }
-
-
 }

--- a/back-end/src/main/java/com/techie/backend/playlist/service/PlaylistServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/playlist/service/PlaylistServiceImpl.java
@@ -35,7 +35,6 @@ public class PlaylistServiceImpl implements PlaylistService {
     @Override
     public Boolean createPlaylist(UserDetailsCustom userDetails, PlaylistRequest.CreatePlaylist request) {
         User user = userService.getUserFromSecurityContext(userDetails);
-
         Playlist playlist = Playlist.builder()
                 .name(request.getName())
                 .user(user)
@@ -87,7 +86,6 @@ public class PlaylistServiceImpl implements PlaylistService {
     @Override
     public PlaylistResponse.Details getPlaylistDetails(Long userId, Long playlistId, UserDetailsCustom userDetails) {
         User user = userService.getUserFromSecurityContext(userDetails);
-
         if (user == null || !user.getId().equals(userId)) {
             throw new UserNotFoundException();
         }
@@ -99,7 +97,6 @@ public class PlaylistServiceImpl implements PlaylistService {
         }
 
         PlaylistResponse.Details response = new PlaylistResponse.Details();
-
         response.setPlaylistId(playlist.getId());
         response.setPlaylistName(playlist.getName());
 
@@ -119,7 +116,6 @@ public class PlaylistServiceImpl implements PlaylistService {
     @Override
     public PlaylistResponse.UpdatePlaylist updatePlaylist(UserDetailsCustom userDetails, PlaylistRequest.UpdatePlaylist request, Long playlistId) {
         User user = userService.getUserFromSecurityContext(userDetails);
-
         Playlist playlist = playlistRepository.findByIdAndUser(playlistId, user);
 
         if (request.getName() != null && !request.getName().isBlank()) {

--- a/back-end/src/main/java/com/techie/backend/user/dto/UserRequest.java
+++ b/back-end/src/main/java/com/techie/backend/user/dto/UserRequest.java
@@ -16,6 +16,7 @@ public class UserRequest {
     @Data
     public static class Update {
         private String nickname;
+        private String oldPassword;
         private String newPassword;
     }
     @Data


### PR DESCRIPTION
## 🔗 관련 이슈

#110 

## 📝 개요

- 회원 수정 시, 새로운 비밀번호만 입력하거나 기존 비밀번호와 함께 새로운 비밀번호를 입력할 수 있도록 DTO에 oldPassword를 추가하였습니다.
- SecurityConfig의 API 엔드포인트 설정을 분리하여 더 체계적이고 관리하기 쉽게 개선하였습니다.
- GPT 엔티티의 Response를 TEXT 타입으로 변경하여, 텍스트 길이로 인해 발생하던 응답 오류를 해결하였습니다.
- 예외처리 핸들러를 추가하여 전반적인 예외 처리를 더욱 안정적으로 구현하였습니다.
- 메모 서비스의 이메일 찾기 코드를 수정하여 기능을 개선하였습니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).