### PR TITLE
[BE] [#139] 메모 서비스 로직 변경

### DIFF
--- a/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
+++ b/back-end/src/main/java/com/techie/backend/memo/controller/MemoController.java
@@ -23,39 +23,39 @@ public class MemoController {
     @PostMapping
     public ResponseEntity<MemoResponse> createMemo(@RequestBody MemoRequest memoRequest,
                                                    @AuthenticationPrincipal UserDetailsCustom userDetails) {
-        return memoService.createMemo(memoRequest, userDetails.getUsername());
+        return memoService.createMemo(memoRequest, userDetails);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<MemoResponse> getMemo(@PathVariable Long id,
                                                 @AuthenticationPrincipal UserDetailsCustom userDetails) throws AccessDeniedException {
-        return memoService.getMemo(userDetails.getUsername(), id);
+        return memoService.getMemo(userDetails, id);
     }
 
     @GetMapping("/list")
     public ResponseEntity<Slice<MemoResponse>> getAllMemos(@AuthenticationPrincipal UserDetailsCustom userDetails,
                                                            @PageableDefault(size = 10) Pageable pageable) {
-        return memoService.getMemoList(userDetails, userDetails.getUsername(), pageable);
+        return memoService.getMemoList(userDetails, pageable);
     }
 
     @GetMapping("/byVideo")
     public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideo(@RequestParam String vId,
                                                                   @AuthenticationPrincipal UserDetailsCustom userDetails,
                                                                   @PageableDefault(size = 10) Pageable pageable) {
-        return memoService.getAllMemosByVideoId(userDetails, userDetails.getUsername(), vId, pageable);
+        return memoService.getAllMemosByVideoId(userDetails, vId, pageable);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<MemoResponse> updateMemo(@PathVariable Long id,
                                                    @RequestBody MemoRequest.Update updateRequest,
                                                    @AuthenticationPrincipal UserDetailsCustom userDetails) throws AccessDeniedException {
-        return memoService.updateMemo(userDetails.getUsername(), id, updateRequest);
+        return memoService.updateMemo(userDetails, id, updateRequest);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteMemo(@PathVariable Long id,
                                              @AuthenticationPrincipal UserDetailsCustom userDetails) throws AccessDeniedException {
-        return memoService.deleteMemo(userDetails.getUsername(), id);
+        return memoService.deleteMemo(userDetails, id);
     }
 
 }

--- a/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
+++ b/back-end/src/main/java/com/techie/backend/memo/dto/MemoResponse.java
@@ -15,14 +15,4 @@ public class MemoResponse {
     private String content;
     private String noteTime;
     private String videoId;
-
-    public static MemoResponse MemoToResponse(Memo memo, Video video) {
-        return new MemoResponse(
-                memo.getId(),
-                memo.getTitle() != null ? memo.getTitle() : null,
-                memo.getContent(),
-                memo.getNoteTime() != null ? memo.getNoteTime() : null,
-                video != null ? video.getVideoId() : null
-        );
-    }
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoService.java
@@ -10,11 +10,11 @@ import org.springframework.http.ResponseEntity;
 import java.nio.file.AccessDeniedException;
 
 public interface MemoService {
-    public ResponseEntity<MemoResponse> createMemo(MemoRequest memoRequest, String username);
-    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, String username, Pageable pageable);
-    public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException;
+    public ResponseEntity<MemoResponse> createMemo(MemoRequest memoRequest, UserDetailsCustom userDetails);
+    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, Pageable pageable);
+    public ResponseEntity<MemoResponse> getMemo(UserDetailsCustom userDetails, Long id) throws AccessDeniedException;
 
-    ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String username, String videoId, Pageable pageable);
-    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException;
-    public ResponseEntity<String> deleteMemo(String username, Long id) throws AccessDeniedException;
+    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String videoId, Pageable pageable);
+    public ResponseEntity<MemoResponse> updateMemo(UserDetailsCustom userDetails, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException;
+    public ResponseEntity<String> deleteMemo(UserDetailsCustom userDetails, Long id) throws AccessDeniedException;
 }

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -48,10 +48,11 @@ public class MemoServiceImpl implements MemoService {
         User user = userRepository.findByEmail(username);
         memo.assignUser(user);
 
+        String videoId = request.getVideoId();
         // 메모 연관 동영상 할당
-        if (request.getVideoId() != null) {
-            Video video = videoRepository.findByVideoId(request.getVideoId())
-                    .orElseThrow(() -> new NoSuchElementException("해당 영상을 찾을 수 없습니다."));
+        if (videoId != null) {
+            Video video = videoRepository.findByVideoId(videoId).orElse(
+                    videoRepository.save(new Video(videoId)));
             memo.assignVideo(video);
         }
 

--- a/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/memo/service/MemoServiceImpl.java
@@ -7,7 +7,6 @@ import com.techie.backend.memo.dto.MemoRequest;
 import com.techie.backend.memo.dto.MemoResponse;
 import com.techie.backend.memo.repository.MemoRepository;
 import com.techie.backend.user.domain.User;
-import com.techie.backend.user.repository.UserRepository;
 import com.techie.backend.user.service.UserService;
 import com.techie.backend.video.domain.Video;
 import com.techie.backend.video.repository.VideoRepository;
@@ -18,12 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.AccessDeniedException;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.Collections;
 
 @Service
 @Transactional
@@ -31,14 +30,13 @@ import java.util.Optional;
 @Slf4j
 public class MemoServiceImpl implements MemoService {
     private final MemoRepository memoRepository;
-    private final UserRepository userRepository;
     private final VideoRepository videoRepository;
     private final UserService userService;
     private final ModelMapper modelMapper;
 
     // -- 메모 생성 --
     @Override
-    public ResponseEntity<MemoResponse> createMemo(MemoRequest request, String username) {
+    public ResponseEntity<MemoResponse> createMemo(MemoRequest request, UserDetailsCustom userDetails) {
         if (request.getContent() == null || request.getContent().isBlank()) {
             throw new EmptyContentException();
         }
@@ -46,7 +44,7 @@ public class MemoServiceImpl implements MemoService {
         Memo memo = modelMapper.map(request, Memo.class);
 
         // 메모 소유자 할당
-        User user = userRepository.findByEmail(username);
+        User user = userService.getUserFromSecurityContext(userDetails);
         memo.assignUser(user);
 
         String videoId = request.getVideoId();
@@ -64,22 +62,23 @@ public class MemoServiceImpl implements MemoService {
 
     // --  메모 목록 조회 --
     @Override
-    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, String username, Pageable pageable) {
+    public ResponseEntity<Slice<MemoResponse>> getMemoList(UserDetailsCustom userDetails, Pageable pageable) {
         User user = userService.getUserFromSecurityContext(userDetails);
         Slice<MemoResponse> memoSlice = memoRepository.findByUser(user, pageable)
-                                        .map(m -> MemoResponse.MemoToResponse(m, m.getVideo()));
+                                        .map(m -> modelMapper.map(m, MemoResponse.class));
 
         return ResponseEntity.ok(memoSlice);
     }
 
     // -- 메모 단건 조회 --
     @Override
-    public ResponseEntity<MemoResponse> getMemo(String username, Long id) throws AccessDeniedException {
+    public ResponseEntity<MemoResponse> getMemo(UserDetailsCustom userDetails, Long id) throws AccessDeniedException {
         Memo memo = memoRepository.findById(id)
                 .orElseThrow(()->new EntityNotFoundException("메모를 찾을 수 없습니다."));
 
+        User user = userService.getUserFromSecurityContext(userDetails);
         // 현재 사용자와 메모 소유자가 일치하는 지 확인
-        if(!memo.getUser().equals(userRepository.findByEmail(username))) {
+        if(!memo.getUser().equals(user)) {
             throw new AccessDeniedException("해당 메모에 접근할 권한이 없습니다.");
         }
 
@@ -89,26 +88,27 @@ public class MemoServiceImpl implements MemoService {
 
     // -- 영상 별 메모 조회
     @Override
-    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String username, String videoId, Pageable pageable) {
+    public ResponseEntity<Slice<MemoResponse>> getAllMemosByVideoId(UserDetailsCustom userDetails, String videoId, Pageable pageable) {
         User user = userService.getUserFromSecurityContext(userDetails);
-        Video video = videoRepository.findByVideoId(videoId).orElse(null);
 
-        Slice<MemoResponse> memoSlice = Optional.ofNullable(video)
-                .map(v -> memoRepository.findByUserAndVideo(user, v, pageable)
-                        .map(m -> MemoResponse.MemoToResponse(m, m.getVideo())))
-                .orElseThrow(() -> new EntityNotFoundException("해당 영상에 쓴 메모가 없습니다"));
-
-        return ResponseEntity.ok(memoSlice);
+        // 조건에 맞는 정보가 없다면 빈 슬라이스 반환
+        return ResponseEntity.ok(
+                videoRepository.findByVideoId(videoId)
+                        .map(video -> memoRepository.findByUserAndVideo(user, video, pageable)
+                                .map(memo -> modelMapper.map(memo, MemoResponse.class)))
+                        .orElseGet(() -> new SliceImpl<>(Collections.emptyList(), pageable, false))
+        );
     }
 
     // -- 메모 수정 --
     @Override
-    public ResponseEntity<MemoResponse> updateMemo(String username, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException {
+    public ResponseEntity<MemoResponse> updateMemo(UserDetailsCustom userDetails, Long id, MemoRequest.Update updateRequest) throws AccessDeniedException {
         Memo memo = memoRepository.findById(id)
                 .orElseThrow(()->new EntityNotFoundException("메모를 찾을 수 없습니다."));
 
+        User user = userService.getUserFromSecurityContext(userDetails);
         // 현재 사용자와 메모 소유자가 일치하는 지 확인
-        if(!memo.getUser().equals(userRepository.findByEmail(username))) {
+        if(!memo.getUser().equals(user)) {
             throw new AccessDeniedException("해당 메모에 접근할 권한이 없습니다.");
         }
 
@@ -117,7 +117,7 @@ public class MemoServiceImpl implements MemoService {
         if (content == null || content.isBlank()) {
             throw new EmptyContentException();
         }
-        memo.changeContent(updateRequest.getContent());
+        memo.changeContent(content);
         memoRepository.save(memo);
 
         MemoResponse memoResponse = modelMapper.map(memo, MemoResponse.class);
@@ -126,12 +126,14 @@ public class MemoServiceImpl implements MemoService {
 
     // -- 메모 삭제 --
     @Override
-    public ResponseEntity<String> deleteMemo(String username, Long id) throws AccessDeniedException {
+    public ResponseEntity<String> deleteMemo(UserDetailsCustom userDetails, Long id) throws AccessDeniedException {
         Memo memo = memoRepository.findById(id)
                 .orElseThrow(()->new EntityNotFoundException("메모를 찾을 수 없습니다."));
 
+        User user = userService.getUserFromSecurityContext(userDetails);
+
         // 현재 사용자와 메모 소유자가 일치하는 지 확인
-        if(!memo.getUser().equals(userRepository.findByEmail(username))) {
+        if(!memo.getUser().equals(user)) {
             throw new AccessDeniedException("해당 메모에 접근할 권한이 없습니다.");
         }
 

--- a/back-end/src/main/java/com/techie/backend/video/domain/Video.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Video.java
@@ -17,7 +17,7 @@ public class Video {
     @Id
     private String videoId;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String title;
 
     @Enumerated(EnumType.STRING)
@@ -26,4 +26,8 @@ public class Video {
 
     @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaylistVideo> playlistVideos = new ArrayList<>();
+
+    public Video(String videoId){
+        this.videoId = videoId;
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#139 

## 📝 개요
동영상 DB 방식에서 API 방식으로 변경됨에 따라, 메모 서비스 로직도 변경이 필요하여 수정하고자 합니다.


## 🛠️ 작업 내용
- 이제 영상 정보를 미리 DB에 저장해두지 않기때문에, 사용자가 메모를 작성하려고 할 때가 되어서야 영상을 DB에 저장합니다.
- 이때 영상 테이블에는 영상 id만 저장됩니다.
- 이후 사용자가 해당 영상에 관련된 메모를 조회하고자 할 때, 이미 영상은 메모를 작성한 시기에 저장되었기 때문에
정상적으로 조회할 수 있습니다. 
- 또한 메모 전체 목록과 영상별 목록에서 조건에 맞는 메모가 없을 경우 빈 슬라이스를 반환합니다. 
<br/>



- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).