### PR TITLE
[FE] [#146] 강사 리스트 메모 기능 연결

### DIFF
--- a/front-end/src/app/api/teacherAPI.ts
+++ b/front-end/src/app/api/teacherAPI.ts
@@ -65,5 +65,10 @@ export const getAllVideos = async (): Promise<Video[]> => {
     .map((inst) => getLatestVideos(inst.channeld!));
 
   const results = await Promise.all(promises);
-  return results.flat();
+
+  const allVideos = results.flat();
+
+  allVideos.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+
+  return allVideos;
 };

--- a/front-end/src/app/teacher-lists/[category]/[videoId]/page.tsx
+++ b/front-end/src/app/teacher-lists/[category]/[videoId]/page.tsx
@@ -1,0 +1,386 @@
+'use client';
+
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import { fetchVideoDetails } from '@/app/api/videoAPIDetail';
+import { saveMemo, updateMemo, deleteMemo, getMemosByVideo } from '@/app/api/memoAPI';
+import '@/styles/pages/playlist/playlist.scss';
+
+interface VideoDetails {
+  title: string;
+  channelTitle: string;
+}
+
+interface Memo {
+  id?: string;
+  noteTime: string;
+  content: string;
+  videoId: string;
+}
+
+// YouTube API를 동적으로 로드
+const loadYouTubeAPI = (onReady: () => void) => {
+  if (!window.YT) {
+    const script = document.createElement('script');
+    script.src = 'https://www.youtube.com/iframe_api';
+    script.async = true;
+    document.body.appendChild(script);
+
+    window.onYouTubeIframeAPIReady = () => {
+      onReady();
+    };
+  } else {
+    onReady();
+  }
+};
+
+const VideoPlayerPage: React.FC = () => {
+  const { videoId } = useParams();
+  const [videoDetails, setVideoDetails] = useState<VideoDetails | null>(null);
+  const [isYouTubeAPIReady, setIsYouTubeAPIReady] = useState(false);
+  const [memoText, setMemoText] = useState('');
+  const [memos, setMemos] = useState<Memo[]>([]);
+  const [memoTime, setMemoTime] = useState<string | null>(null);
+  const [editingMemoId, setEditingMemoId] = useState<string | null>(null);
+  const [isAddingMemo, setIsAddingMemo] = useState(false);
+  const [editedMemoContent, setEditedMemoContent] = useState('');
+  const [editedMemoTime, setEditedMemoTime] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [hasMoreMemos, setHasMoreMemos] = useState(true);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const [memoToDelete, setMemoToDelete] = useState<string | null>(null);
+  const playerRef = useRef<YT.Player | null>(null);
+
+  // YouTube API 로드
+  useEffect(() => {
+    loadYouTubeAPI(() => setIsYouTubeAPIReady(true));
+  }, []);
+
+  // YouTube 플레이어 상태 변경 핸들러
+  const handlePlayerStateChange = useCallback((event: YT.PlayerStateChangeEvent) => {
+    if (event.data === YT.PlayerState.PAUSED && playerRef.current) {
+      const currentTime = playerRef.current.getCurrentTime
+        ? Math.floor(playerRef.current.getCurrentTime())
+        : 0;
+      const formattedTime = formatTime(currentTime);
+
+      setMemoTime(formattedTime);
+    }
+  }, []);
+
+  // YouTube 플레이어 초기화
+  useEffect(() => {
+    if (isYouTubeAPIReady && videoId && !playerRef.current) {
+      try {
+        playerRef.current = new window.YT.Player('youtube-player', {
+          videoId: videoId as string,
+          events: {
+            onStateChange: handlePlayerStateChange,
+          },
+        });
+      } catch (error) {
+        console.error('Failed to initialize YouTube Player:', error);
+      }
+    }
+  }, [isYouTubeAPIReady, videoId, handlePlayerStateChange]);
+
+  // 시간을 포맷팅
+  const formatTime = (seconds: number): string => {
+    const date = new Date(0);
+    date.setSeconds(seconds);
+    return date.toISOString().substr(14, 5);
+  };
+
+  // 메모 초기화
+  const resetMemo = () => {
+    setMemoText('');
+    setIsAddingMemo(false);
+    setMemoTime(null);
+  };
+
+  // 메모 추가
+  const handleAddMemo = () => {
+    if (playerRef.current?.getCurrentTime) {
+      const currentTime = Math.floor(playerRef.current.getCurrentTime());
+      const formattedTime = formatTime(currentTime);
+
+      setMemoTime(formattedTime);
+      setIsAddingMemo(true);
+    } else {
+      console.error('Player is not initialized. Cannot add memo.');
+    }
+  };
+
+  // 메모 저장
+  const handleSaveMemo = async () => {
+    if (!memoText.trim() || !memoTime) {
+      console.warn('Memo text or time is missing:', { memoText, memoTime });
+      return;
+    }
+
+    try {
+      const payload = {
+        title: videoDetails?.title || '',
+        content: memoText,
+        noteTime: memoTime || '00:00',
+        videoId,
+      };
+
+      await saveMemo(payload);
+
+      const updatedResponse = await getMemosByVideo(videoId, 0);
+      setMemos(updatedResponse.data.content);
+      setCurrentPage(0);
+      setHasMoreMemos(!updatedResponse.data.last);
+    } catch (error) {
+      console.error('Failed to save memo:', error);
+    }
+
+    resetMemo();
+  };
+
+  // 메모 수정 시작
+  const handleEditMemo = (memo: Memo) => {
+    setEditingMemoId(memo.id || null);
+    setEditedMemoContent(memo.content);
+    setEditedMemoTime(memo.noteTime || '00:00');
+  };
+
+  // 메모 수정 취소
+  const handleCancelEdit = () => {
+    setEditingMemoId(null);
+    setEditedMemoContent('');
+    setEditedMemoTime(null);
+  };
+
+  // 메모 수정 저장
+  const handleSaveEditedMemo = async (memoId: string) => {
+    if (!editedMemoContent.trim() || !editedMemoTime) {
+      console.warn('Edited memo text or time is missing:', {
+        editedMemoContent,
+        editedMemoTime,
+      });
+      return;
+    }
+
+    try {
+      const payload = {
+        noteTime: editedMemoTime || '00:00',
+        content: editedMemoContent,
+      };
+
+      await updateMemo(memoId, payload);
+
+      const updatedResponse = await getMemosByVideo(videoId, 0);
+      setMemos(updatedResponse.data.content);
+      setCurrentPage(0);
+      setHasMoreMemos(!updatedResponse.data.last);
+    } catch (error) {
+      console.error('Failed to update memo:', error);
+    }
+
+    handleCancelEdit();
+  };
+
+  // 메모 삭제
+  const handleDeleteMemo = async (memoId: string) => {
+    if (!memoId) {
+      console.warn('Memo ID is missing for deletion');
+      return;
+    }
+
+    try {
+      await deleteMemo(memoId);
+
+      const updatedResponse = await getMemosByVideo(videoId, 0);
+      setMemos(updatedResponse.data.content);
+      setCurrentPage(0);
+      setHasMoreMemos(!updatedResponse.data.last);
+    } catch (error) {
+      console.error('Failed to delete memo:', error);
+    }
+  };
+
+  // 특정 시간대로 이동
+  const handleTimeClick = (time: string | undefined) => {
+    if (!time) {
+      console.error('Time is missing for memo');
+      return;
+    }
+
+    if (playerRef.current?.seekTo) {
+      const [minutes, seconds] = time.split(':').map(Number);
+      playerRef.current.seekTo(minutes * 60 + seconds, true);
+    } else {
+      console.error('Player is not initialized.');
+    }
+  };
+
+  // 메모 리스트 가져오기
+  const fetchMemosForVideo = useCallback(
+    async (page: number) => {
+      try {
+        const response = await getMemosByVideo(videoId, page);
+
+        setMemos((prevMemos) =>
+          page === 0 ? response.data.content : [...prevMemos, ...response.data.content],
+        );
+
+        const isEmptyContent = response.data.empty || response.data.content.length === 0;
+        setHasMoreMemos(!isEmptyContent && !response.data.last);
+      } catch (error) {
+        console.error('Failed to fetch memos for video:', error);
+      }
+    },
+    [videoId],
+  );
+
+  // 메모 페이지네이션
+  useEffect(() => {
+    fetchMemosForVideo(currentPage);
+  }, [currentPage, fetchMemosForVideo]);
+
+  // 동영상 정보 가져오기
+  useEffect(() => {
+    const fetchVideoDetailsAsync = async () => {
+      if (videoId) {
+        try {
+          const details = await fetchVideoDetails(videoId as string);
+          setVideoDetails(details);
+        } catch (error) {
+          console.error('Failed to fetch video details:', error);
+        }
+      }
+    };
+
+    fetchVideoDetailsAsync();
+  }, [videoId]);
+
+  // 무한 스크롤 처리
+  const lastMemoElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasMoreMemos) {
+          setCurrentPage((prevPage) => prevPage + 1);
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [hasMoreMemos],
+  );
+
+  return (
+    <div className="video_player_container">
+      <div className="video_content">
+        <h3 className="video_title">{videoDetails?.title}</h3>
+        <div className="video_frame_and_memo">
+          <div id="youtube-player" className="video_frame"></div>
+          <div className="memo_container">
+            <h4 className="save_memo_title">메모 목록</h4>
+            <p>메모를 클릭하여 수정하거나 삭제할 수 있습니다.✏️</p>
+            <p>내 전체 메모는 마이페이지에서 확인이 가능합니다.🍀</p>
+            <div className="memo_list">
+              {memos.length > 0 ? (
+                memos.map((memo, index) => {
+                  const isLastMemo = memos.length === index + 1;
+                  return (
+                    <div
+                      key={memo.id}
+                      className="memo_item"
+                      ref={isLastMemo ? lastMemoElementRef : null}
+                    >
+                      <span
+                        className="memo_time"
+                        onClick={() => {
+                          handleTimeClick(memo.noteTime);
+                        }}
+                      >
+                        {memo.noteTime || '시간 없음'}
+                      </span>
+                      {editingMemoId === memo.id ? (
+                        // 편집 중인 메모
+                        <div className="memo_edit_form">
+                          <textarea
+                            value={editedMemoContent}
+                            onChange={(e) => setEditedMemoContent(e.target.value)}
+                            className="memo_input"
+                          ></textarea>
+                          <div className="memo_actions">
+                            <button onClick={() => handleSaveEditedMemo(memo.id!)}>저장</button>
+                            <button onClick={handleCancelEdit}>취소</button>
+                          </div>
+                        </div>
+                      ) : (
+                        // 일반 메모
+                        <>
+                          <p className="memo_content">{memo.content || '내용 없음'}</p>
+                          <div className="memo_actions">
+                            <button onClick={() => handleEditMemo(memo)}>수정</button>
+                            <button onClick={() => setMemoToDelete(memo.id!)}>삭제</button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  );
+                })
+              ) : (
+                <p className="memo_notice">메모가 없습니다. 메모를 추가해보세요!</p>
+              )}
+            </div>
+
+            {isAddingMemo ? (
+              <div className="memo_form">
+                <div className="memo_time_display">{memoTime}</div>
+                <textarea
+                  placeholder="메모를 입력하세요"
+                  value={memoText}
+                  className="memo_input"
+                  onChange={(e) => setMemoText(e.target.value)}
+                ></textarea>
+                <div className="form_actions">
+                  <button className="cancel_button" onClick={resetMemo}>
+                    취소
+                  </button>
+                  <button className="save_button" onClick={handleSaveMemo}>
+                    메모 저장
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button onClick={handleAddMemo} className="add_button">
+                메모 추가
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {memoToDelete && (
+        <div className="modal">
+          <div className="modal_content">
+            <p>정말 삭제하시겠습니까?</p>
+            <div className="modal_actions">
+              <button className="cancel_button" onClick={() => setMemoToDelete(null)}>
+                취소
+              </button>
+              <button
+                className="save_button"
+                onClick={() => {
+                  handleDeleteMemo(memoToDelete);
+                  setMemoToDelete(null);
+                }}
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VideoPlayerPage;

--- a/front-end/src/app/teacher-lists/[category]/page.tsx
+++ b/front-end/src/app/teacher-lists/[category]/page.tsx
@@ -8,7 +8,11 @@ import TeacherPlaylist from '@/components/playlist/TeacherPlaylist';
 
 const TeacherCategoryPage: React.FC = () => {
   const params = useParams();
-  const teacherName = decodeURIComponent(params.category);
+
+  // category 값을 안전하게 string으로 변환
+  const teacherName = Array.isArray(params.category)
+    ? decodeURIComponent(params.category[0])
+    : decodeURIComponent(params.category);
 
   const instructor = instructorData.find((instructor) => instructor.name === teacherName);
 
@@ -18,7 +22,7 @@ const TeacherCategoryPage: React.FC = () => {
 
   return (
     <div className="playlists_container">
-      <TeacherPlaylist playlistId={instructor.playlistId} />
+      <TeacherPlaylist channelId={instructor.channeld} />
     </div>
   );
 };

--- a/front-end/src/app/teacher-lists/[category]/page.tsx
+++ b/front-end/src/app/teacher-lists/[category]/page.tsx
@@ -2,14 +2,12 @@
 
 import React from 'react';
 import { useParams } from 'next/navigation';
-
 import instructorData from '@/data/instructorData';
 import TeacherPlaylist from '@/components/playlist/TeacherPlaylist';
 
 const TeacherCategoryPage: React.FC = () => {
   const params = useParams();
 
-  // category 값을 안전하게 string으로 변환
   const teacherName = Array.isArray(params.category)
     ? decodeURIComponent(params.category[0])
     : decodeURIComponent(params.category);

--- a/front-end/src/components/playlist/TeacherPlaylist.tsx
+++ b/front-end/src/components/playlist/TeacherPlaylist.tsx
@@ -1,53 +1,72 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
-import instructorData from '@/data/instructorData';
 import { useQuery } from '@tanstack/react-query';
+import instructorData from '@/data/instructorData';
 import { getAllVideos, getLatestVideos } from '@/app/api/teacherAPI';
 import { Video } from '@/types/video';
 
-const TeacherPlaylist = () => {
-  const [selected, setSelected] = useState(instructorData[0]);
+interface TeacherPlaylistProps {
+  channelId: string; // 강사의 채널 ID를 받는 Prop
+}
 
-  // 전체 강사의 동영상 가져오기
+const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
+  const [selected, setSelected] = useState(
+    instructorData.find((inst) => inst.channeld === channelId) || instructorData[0],
+  ); // 선택된 강사 상태 관리
+
+  // React Query로 전체 강사의 동영상 가져오기
   const allQuery = useQuery<Video[], Error>({
     queryKey: ['allVideos'],
     queryFn: getAllVideos,
-    enabled: selected.name === '전체',
-    staleTime: 1000 * 60 * 30,
+    enabled: selected.name === '전체', // "전체" 강사가 선택된 경우만 실행
+    staleTime: 1000 * 60 * 30, // 30분 동안 데이터 캐시
   });
 
-  // 특정 강사의 동영상을 가져오기
+  // React Query로 특정 강사의 최신 동영상 가져오기
   const instQuery = useQuery<Video[], Error>({
     queryKey: ['instVideos', selected.channeld],
     queryFn: () => getLatestVideos(selected.channeld!),
-    enabled: selected.name !== '전체' && !!selected.channeld,
-    staleTime: 1000 * 60 * 10,
+    enabled: selected.name !== '전체' && !!selected.channeld, // 특정 강사가 선택된 경우 실행
+    staleTime: 1000 * 60 * 10, // 10분 동안 데이터 캐시
   });
 
+  // 선택된 강사에 따라 동영상 데이터 결정
   const videos = selected.name === '전체' ? allQuery.data || [] : instQuery.data || [];
+
+  useEffect(() => {
+    const matchedInstructor = instructorData.find((inst) => inst.channeld === channelId);
+    if (matchedInstructor) {
+      setSelected(matchedInstructor); // channelId에 따라 상태 초기화
+    }
+  }, [channelId]);
 
   return (
     <div className="playlists_container">
       <ul className="dev_list teacher">
         {instructorData.map((inst) => (
-          <li key={inst.name}>
-            <button type="button" onClick={() => setSelected(inst)}>
+          <li key={inst.name} className={selected.name === inst.name ? 'active' : ''}>
+            <button
+              type="button"
+              onClick={() => setSelected(inst)}
+              disabled={selected.name === inst.name}
+            >
               <Image src={inst.img} alt={inst.name} width={70} height={70} />
               <span>{inst.name}</span>
             </button>
           </li>
         ))}
       </ul>
+
       <div className="video_list_cont">
         <div className="inner">
           <ul className="video_list">
             {allQuery.isLoading || instQuery.isLoading ? (
               <p>로딩 중입니다...</p>
             ) : videos.length > 0 ? (
-              videos.map((video, index) => (
-                <li key={index} className="video_item">
+              videos.map((video) => (
+                <li key={video.videoId} className="video_item">
                   <a
                     href={`https://www.youtube.com/watch?v=${video.videoId}`}
                     target="_blank"

--- a/front-end/src/components/playlist/TeacherPlaylist.tsx
+++ b/front-end/src/components/playlist/TeacherPlaylist.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import instructorData from '@/data/instructorData';
 import { getAllVideos, getLatestVideos } from '@/app/api/teacherAPI';
@@ -20,7 +21,7 @@ const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
   const allQuery = useQuery<Video[], Error>({
     queryKey: ['allVideos'],
     queryFn: getAllVideos,
-    enabled: selected.name === '전체', // "전체" 강사가 선택된 경우만 실행
+    enabled: selected.name === 'ALL', // "전체" 강사가 선택된 경우만 실행
     staleTime: 1000 * 60 * 30, // 30분 동안 데이터 캐시
   });
 
@@ -67,11 +68,7 @@ const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
             ) : videos.length > 0 ? (
               videos.map((video) => (
                 <li key={video.videoId} className="video_item">
-                  <a
-                    href={`https://www.youtube.com/watch?v=${video.videoId}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <Link href={`/playlists/${selected.name}/${video.videoId}`}>
                     <Image
                       src={video.thumbnails.medium.url}
                       alt={video.title}
@@ -81,7 +78,7 @@ const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
                     <h3 className="title">{video.title}</h3>
                     <p className="channel_title">{video.channelTitle}</p>
                     <p className="date">{new Date(video.publishedAt).toLocaleDateString()}</p>
-                  </a>
+                  </Link>
                 </li>
               ))
             ) : (

--- a/front-end/src/components/playlist/TeacherPlaylist.tsx
+++ b/front-end/src/components/playlist/TeacherPlaylist.tsx
@@ -9,28 +9,28 @@ import { getAllVideos, getLatestVideos } from '@/app/api/teacherAPI';
 import { Video } from '@/types/video';
 
 interface TeacherPlaylistProps {
-  channelId: string; // 강사의 채널 ID를 받는 Prop
+  channelId: string;
 }
 
 const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
   const [selected, setSelected] = useState(
     instructorData.find((inst) => inst.channeld === channelId) || instructorData[0],
-  ); // 선택된 강사 상태 관리
+  );
 
   // React Query로 전체 강사의 동영상 가져오기
   const allQuery = useQuery<Video[], Error>({
     queryKey: ['allVideos'],
     queryFn: getAllVideos,
-    enabled: selected.name === 'ALL', // "전체" 강사가 선택된 경우만 실행
-    staleTime: 1000 * 60 * 30, // 30분 동안 데이터 캐시
+    enabled: selected.name === 'ALL',
+    staleTime: 1000 * 60 * 30,
   });
 
   // React Query로 특정 강사의 최신 동영상 가져오기
   const instQuery = useQuery<Video[], Error>({
     queryKey: ['instVideos', selected.channeld],
     queryFn: () => getLatestVideos(selected.channeld!),
-    enabled: selected.name !== '전체' && !!selected.channeld, // 특정 강사가 선택된 경우 실행
-    staleTime: 1000 * 60 * 10, // 10분 동안 데이터 캐시
+    enabled: selected.name !== '전체' && !!selected.channeld,
+    staleTime: 1000 * 60 * 10,
   });
 
   // 선택된 강사에 따라 동영상 데이터 결정
@@ -39,7 +39,7 @@ const TeacherPlaylist: React.FC<TeacherPlaylistProps> = ({ channelId }) => {
   useEffect(() => {
     const matchedInstructor = instructorData.find((inst) => inst.channeld === channelId);
     if (matchedInstructor) {
-      setSelected(matchedInstructor); // channelId에 따라 상태 초기화
+      setSelected(matchedInstructor);
     }
   }, [channelId]);
 

--- a/front-end/src/data/instructorData.js
+++ b/front-end/src/data/instructorData.js
@@ -1,6 +1,6 @@
 const instructorData = [
   {
-    name: '전체',
+    name: 'ALL',
     description: '전체 강좌 목록을 확인할 수 있어요',
     img: '/assets/images/main/logo06.jpg',
     channeld: '',

--- a/front-end/src/data/instructorData.js
+++ b/front-end/src/data/instructorData.js
@@ -3,7 +3,7 @@ const instructorData = [
     name: 'ALL',
     description: '전체 강좌 목록을 확인할 수 있어요',
     img: '/assets/images/main/logo06.jpg',
-    channeld: '',
+    channeld: null,
   },
   {
     name: '생활코딩',

--- a/front-end/src/types/video.d.ts
+++ b/front-end/src/types/video.d.ts
@@ -41,6 +41,25 @@ export interface Video {
   };
 }
 
+export interface PlaylistResponse {
+  kind: string;
+  etag: string;
+  items: {
+    kind: string;
+    etag: string;
+    id: string;
+    snippet: VideoSnippet;
+    contentDetails: {
+      videoId: string;
+      videoPublishedAt: string;
+    };
+  }[];
+  pageInfo: {
+    totalResults: number;
+    resultsPerPage: number;
+  };
+}
+
 export interface FetchVideosOptions {
   category?: string;
   query?: string;

--- a/front-end/src/types/video.d.ts
+++ b/front-end/src/types/video.d.ts
@@ -44,6 +44,7 @@ export interface Video {
 export interface PlaylistResponse {
   kind: string;
   etag: string;
+  nextPageToken?: string;
   items: {
     kind: string;
     etag: string;
@@ -52,6 +53,25 @@ export interface PlaylistResponse {
     contentDetails: {
       videoId: string;
       videoPublishedAt: string;
+    };
+  }[];
+  pageInfo: {
+    totalResults: number;
+    resultsPerPage: number;
+  };
+}
+
+export interface ChannelResponse {
+  kind: string;
+  etag: string;
+  items: {
+    kind: string;
+    etag: string;
+    id: string;
+    contentDetails: {
+      relatedPlaylists: {
+        uploads: string;
+      };
     };
   }[];
   pageInfo: {


### PR DESCRIPTION
## 🔗 관련 이슈

#146 

## 📝 개요

- 기존에는 강의탐색 부분만 메모 상세 페이지를 연동했는데, 강사 리스트에도 연동 완료했습니다.
- 무한 스크롤의 경우 YouTube API의 제한으로 인해 클라이언트 측에서 구현하기가 어려워 나중에 백엔드로 연동하는 형식으로 변동하거나 메뉴를 삭제 하는 것으로 수정해야할 것 같습니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).