### PR TITLE
[BE] [#148] 영상 제목까지 저장하도록 수정

### DIFF
--- a/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
+++ b/back-end/src/main/java/com/techie/backend/video/controller/VideoController.java
@@ -32,7 +32,7 @@ public class VideoController {
     }
 
     @GetMapping("/list")
-    public Slice<VideoResponse> AllVideos (Pageable pageable) throws JsonProcessingException {
+    public Slice<VideoResponse> allVideos (Pageable pageable) throws JsonProcessingException {
         return videoService.fetchVideosFromAllCategories(pageable);
     }
 }

--- a/back-end/src/main/java/com/techie/backend/video/domain/Video.java
+++ b/back-end/src/main/java/com/techie/backend/video/domain/Video.java
@@ -28,10 +28,6 @@ public class Video {
     @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaylistVideo> playlistVideos = new ArrayList<>();
 
-    public Video(String videoId){
-        this.videoId = videoId;
-    }
-
     @Builder
     public Video(String videoId, String title) {
         this.videoId = videoId;


### PR DESCRIPTION
## 🔗 관련 이슈
#148 

## 📝 개요
메모 기능을 위해 영상 ID 만 저장하도록 하였으나, 플레이리스트 기능에
영상 제목도 필요로 하여 수정합니다.

## 🛠️ 작업 내용
YouTube 비디오 ID를 기반으로 Video 엔티티를 조회합니다. 만약 비디오가 데이터베이스에 
존재하지 않는 경우 YouTube API를 호출하여 비디오 정보(id, title)를 저장한 뒤, 이를 메모(Memo) 객체에 연결합니다.
<br/>
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).