### PR TITLE
[BE] [#156] GPT 서비스 deprecated 문제 해결

### DIFF
--- a/back-end/src/main/java/com/techie/backend/global/exception/ExceptionType.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/ExceptionType.java
@@ -20,8 +20,10 @@ public enum ExceptionType {
     NO_CHANGES(HttpStatus.NOT_MODIFIED, "변경사항이 없습니다"),
     INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 값입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    INVALID_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 올바르지 않습니다.");
-
+    INVALID_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 올바르지 않습니다."),
+    GPT_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "GPT API 요청 중 문제가 발생했습니다."),
+    GPT_RESPONSE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GPT 응답을 처리하는 중 문제가 발생했습니다."),
+    INVALID_GPT_REQUEST(HttpStatus.BAD_REQUEST, "GPT 요청은 비어있을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/back-end/src/main/java/com/techie/backend/global/exception/GlobalExceptionHandler.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.techie.backend.global.exception;
 
+import com.techie.backend.global.exception.gpt.GptRequestException;
+import com.techie.backend.global.exception.gpt.GptResponseParseException;
+import com.techie.backend.global.exception.gpt.InvalidGptRequestException;
 import com.techie.backend.global.exception.memo.EmptyContentException;
 import com.techie.backend.global.exception.playlist.InvalidVideoIdException;
 import com.techie.backend.global.exception.playlist.PlaylistNotFoundException;
@@ -100,5 +103,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NewPasswordMisMatchException.class)
     public ResponseEntity<Map<String, Object>> handleNewPasswordMisMatchException(NewPasswordMisMatchException ex) {
         return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(GptRequestException.class)
+    public ResponseEntity<Map<String, Object>> handleGptRequestException(GptRequestException ex) {
+        return buildErrorResponse(ex.getMessage(), ex.getExceptionType().getStatus());
+    }
+
+    @ExceptionHandler(GptResponseParseException.class)
+    public ResponseEntity<Map<String, Object>> handleGptResponseParseException(GptResponseParseException ex) {
+        return buildErrorResponse(ex.getMessage(), ex.getExceptionType().getStatus());
+    }
+
+    @ExceptionHandler(InvalidGptRequestException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidGptRequestException(InvalidGptRequestException ex) {
+        return buildErrorResponse(ex.getMessage(), ex.getExceptionType().getStatus());
     }
 }

--- a/back-end/src/main/java/com/techie/backend/global/exception/gpt/GptRequestException.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/gpt/GptRequestException.java
@@ -1,0 +1,14 @@
+package com.techie.backend.global.exception.gpt;
+
+import com.techie.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class GptRequestException extends RuntimeException {
+  private final ExceptionType exceptionType;
+
+  public GptRequestException() {
+    super(ExceptionType.GPT_REQUEST_FAILED.getMessage());
+    this.exceptionType = ExceptionType.GPT_REQUEST_FAILED;
+  }
+}

--- a/back-end/src/main/java/com/techie/backend/global/exception/gpt/GptResponseParseException.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/gpt/GptResponseParseException.java
@@ -1,0 +1,14 @@
+package com.techie.backend.global.exception.gpt;
+
+import com.techie.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class GptResponseParseException extends RuntimeException {
+  private final ExceptionType exceptionType;
+
+  public GptResponseParseException() {
+    super(ExceptionType.GPT_RESPONSE_PARSE_FAILED.getMessage());
+    this.exceptionType = ExceptionType.GPT_RESPONSE_PARSE_FAILED;
+  }
+}

--- a/back-end/src/main/java/com/techie/backend/global/exception/gpt/InvalidGptRequestException.java
+++ b/back-end/src/main/java/com/techie/backend/global/exception/gpt/InvalidGptRequestException.java
@@ -1,0 +1,14 @@
+package com.techie.backend.global.exception.gpt;
+
+import com.techie.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class InvalidGptRequestException extends RuntimeException {
+  private final ExceptionType exceptionType;
+
+  public InvalidGptRequestException() {
+    super(ExceptionType.INVALID_GPT_REQUEST.getMessage());
+    this.exceptionType = ExceptionType.INVALID_GPT_REQUEST;
+  }
+}

--- a/back-end/src/main/java/com/techie/backend/gpt/domain/Gpt.java
+++ b/back-end/src/main/java/com/techie/backend/gpt/domain/Gpt.java
@@ -16,11 +16,11 @@ public class Gpt {
     private long id;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String request;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String response;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/back-end/src/main/java/com/techie/backend/gpt/service/GptServiceImpl.java
+++ b/back-end/src/main/java/com/techie/backend/gpt/service/GptServiceImpl.java
@@ -2,6 +2,8 @@ package com.techie.backend.gpt.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techie.backend.global.exception.gpt.GptRequestException;
+import com.techie.backend.global.exception.gpt.InvalidGptRequestException;
 import com.techie.backend.global.security.UserDetailsCustom;
 import com.techie.backend.gpt.domain.Gpt;
 import com.techie.backend.gpt.dto.GptRequest;
@@ -12,20 +14,21 @@ import com.techie.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +37,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class GptServiceImpl implements GptService {
 
-    private static final Logger logger = LoggerFactory.getLogger(GptServiceImpl.class);
     private final ObjectMapper objectMapper;
     private final GptRepository gptRepository;
     private final UserRepository userRepository;
@@ -49,13 +51,16 @@ public class GptServiceImpl implements GptService {
         String request = gptRequest.getRequest();
 
         if (request == null || request.isEmpty()) {
-            throw new IllegalArgumentException("The GPT request cannot be null or empty");
+            throw new InvalidGptRequestException();
         }
 
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpPost httpPost = new HttpPost(API_URL);
             httpPost.setHeader("Authorization", "Bearer " + API_KEY);
             httpPost.setHeader("Content-Type", "application/json");
+
+            String apiHost = new URL(API_URL).getHost();
+            HttpHost targetHost = HttpHost.create("https://" + apiHost);
 
             Map<String, Object> body = new HashMap<>();
             body.put("model", "gpt-3.5-turbo");
@@ -64,18 +69,19 @@ public class GptServiceImpl implements GptService {
             StringEntity entity = new StringEntity(objectMapper.writeValueAsString(body), ContentType.APPLICATION_JSON);
             httpPost.setEntity(entity);
 
-            try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
-                int statusCode = response.getCode();
-                String responseBody = EntityUtils.toString(response.getEntity());
+            HttpClientContext context = HttpClientContext.create();
 
+            try (ClassicHttpResponse response = httpClient.executeOpen(targetHost, httpPost, context)) {
+                int statusCode = response.getCode();
                 if (statusCode != HttpStatus.OK.value()) {
-                    logger.error("Response Status Code: {}", statusCode);
-                    throw new RuntimeException("Failed to get a response from GPT. Status code: " + statusCode);
+                    throw new GptRequestException();
                 }
+
+                String responseBody = new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
 
                 JsonNode rootNode = objectMapper.readTree(responseBody);
                 String gptContent = rootNode.path("choices").get(0).path("message").path("content").asText();
-                User user = userRepository.findByEmail((userDetails.getUsername()));
+                User user = userRepository.findByEmail(userDetails.getUsername());
 
                 Gpt gpt = new Gpt();
                 gpt.updateRequest(request);
@@ -88,10 +94,10 @@ public class GptServiceImpl implements GptService {
                 gptResponse.setResponse(gptContent);
 
                 return new ResponseEntity<>(gptResponse, HttpStatus.OK);
-            } catch (ParseException e) {
-                throw new RuntimeException("Error parsing the GPT response", e);
             }
         } catch (IOException e) {
+            throw new GptRequestException();
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈

#156 

## 📝 개요

- execute 메서드가 더 이상 지원하지 않으므로 최신 방식인 executeOpen 메서드를 사용했습니다. 
- gpt 서비스 questionAndAnswer 메서드 내부의 예외처리를 ExceptionHandler로 처리하였습니다.
- gpt의 request, response가 너무 길어지면 403 에러가 발생하기에 데이터 타입을 TEXT 타입으로 처리해야했는데, 올바르게 처리가 되지않아 tinytext로 계속 유지되어서, 명확하게 다시 TEXT가 처리되도록 columnDefinition = "TEXT" 을 추가하여 다시 테스트를 거쳐 정상적으로 수정된 것을 확인 했습니다.

## 🛠️ 작업 내용

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).