### PR TITLE
[FE][#176] 1차 배포 이후 QA 반영 프론트엔드 변경사항

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Spring Boot-BackendApplication<back-end>",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "mainClass": "com.techie.backend.BackendApplication",
+      "projectName": "back-end",
+      "args": "",
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}

--- a/front-end/src/app/@isLoginChatbot/page.tsx
+++ b/front-end/src/app/@isLoginChatbot/page.tsx
@@ -119,7 +119,7 @@ const Chatbot = () => {
       <div className="icon">💬</div>
       <div
         className={`chatbot-content_login ${isOpen ? 'isOpen' : ''}`}
-        style={{ left: position.x - 730, top: position.y - 320, position: 'fixed' }}
+        style={{ left: position.x - 630, top: position.y - 300, position: 'fixed' }}
       >
         <div className="chatbot-response" onMouseDown={(e) => e.stopPropagation()}>
           <p>{loading ? '응답을 받아오는 중입니다...' : gptResponse}</p>
@@ -133,7 +133,7 @@ const Chatbot = () => {
           onKeyDown={keyDownEnter}
         ></textarea>
         <button onMouseDown={(e) => e.stopPropagation()} onClick={handleSubmit}>
-          ➡️
+          →
         </button>
       </div>
     </div>

--- a/front-end/src/app/@isLoginChatbot/page.tsx
+++ b/front-end/src/app/@isLoginChatbot/page.tsx
@@ -83,8 +83,6 @@ const Chatbot = () => {
       const apiResponse = await fetchChatBot({ request: textarea, token: token });
       typeResponse(apiResponse.response);
       setTextarea('');
-      console.log(apiResponse.response);
-      console.log('토큰 가져오기 성공', token);
     } catch (error) {
       console.error('함수요청 오류', error);
     } finally {

--- a/front-end/src/app/api/playlistApi.ts
+++ b/front-end/src/app/api/playlistApi.ts
@@ -20,7 +20,6 @@ export const saveVideo = async (
         },
       },
     );
-    console.log('영상저장 성공');
     return response.data;
   } catch (error) {
     console.error('Unexpected error:', error);

--- a/front-end/src/app/login/page.tsx
+++ b/front-end/src/app/login/page.tsx
@@ -60,8 +60,7 @@ const Login = () => {
         console.error('Failed to log in, unexpected response status');
       }
     } catch (error) {
-      console.error('Error during login request:', error);
-      setError('로그인 중 오류가 발생했습니다.');
+      handleLoginError(error);
     }
   };
 

--- a/front-end/src/app/my-video-list/playlistId/[playlistId]/page.tsx
+++ b/front-end/src/app/my-video-list/playlistId/[playlistId]/page.tsx
@@ -20,7 +20,6 @@ const MyVideoList = () => {
   const fetchVideo = useCallback(async () => {
     try {
       const response = await detailPlaylist(playlistId, token);
-      console.log(response);
       setPlaylist(response);
     } catch (error) {
       console.error(error);

--- a/front-end/src/components/mypage/MyVideoSection.tsx
+++ b/front-end/src/components/mypage/MyVideoSection.tsx
@@ -43,22 +43,25 @@ const MyVideoSection: React.FC = () => {
   }, [fetchPlaylists, detailPlaylistData]);
 
   return (
-    <div className="playlist-container">
-      {isLoading && <p>Loading...</p>}
-      {playlists.playlists.length === 0 && !isLoading && <p>저장된 재생목록이 없습니다.</p>}
-      {playlists.playlists.map((playlist) => (
-        <div
-          key={playlist.playlistId}
-          className="playlist-item"
-          onClick={() => {
-            fetchDetailPlaylist(playlist.playlistId);
-            router.push(`my-video-list/playlistId/${playlist.playlistId}`);
-          }}
-        >
-          <h3 className="playlist-name">{playlist.playlistName}</h3>
-          <p>{playlist.videoCount}</p>
-        </div>
-      ))}
+    <div>
+      <h2 className="video-title">내 재생목록 모음</h2>
+      <div className="playlist-container">
+        {isLoading && <p>Loading...</p>}
+        {playlists.playlists.length === 0 && !isLoading && <p>저장된 재생목록이 없습니다.</p>}
+        {playlists.playlists.map((playlist) => (
+          <div
+            key={playlist.playlistId}
+            className="playlist-item"
+            onClick={() => {
+              fetchDetailPlaylist(playlist.playlistId);
+              router.push(`my-video-list/playlistId/${playlist.playlistId}`);
+            }}
+          >
+            <h3 className="playlist-name">{playlist.playlistName}</h3>
+            <p>{playlist.videoCount} 개의 저장된 영상</p>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/front-end/src/components/playlist/CategoryPlaylist.tsx
+++ b/front-end/src/components/playlist/CategoryPlaylist.tsx
@@ -176,7 +176,7 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
       await addVideo(playlistNmae, selectVideo, playlistId, token);
       alert('재생목록에 영상이 추가되었습니다');
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
     closeModal();
     setSelectVideo('');
@@ -199,7 +199,7 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
       );
       alert('재생목록이 삭제 되었습니다');
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
     closeModal();
     setSelectVideo('');

--- a/front-end/src/components/playlist/CategoryPlaylist.tsx
+++ b/front-end/src/components/playlist/CategoryPlaylist.tsx
@@ -35,6 +35,7 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
   const [playlists, setPlaylists] = useState<PlayLists | undefined>(undefined);
   const [loadingVideos, setLoadingVideos] = useState(true);
   const [loadingPlaylists, setLoadingPlaylists] = useState(true);
+  const maxLength = 15;
 
   // 비디오 로딩 함수
   const loadVideos = useCallback(
@@ -106,6 +107,7 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
   const closeModal = () => {
     setShowModal(false);
     setPlayListName('');
+    setSelectVideo('');
   };
 
   const handleSaveVideo = async () => {
@@ -179,7 +181,6 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
       console.error(error);
     }
     closeModal();
-    setSelectVideo('');
   };
 
   // 재생목록 삭제
@@ -202,7 +203,15 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
       console.error(error);
     }
     closeModal();
-    setSelectVideo('');
+  };
+
+  const onChangePlaylistName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (value.length <= maxLength) {
+      setPlayListName(value);
+    } else {
+      alert('재생목록의 이름은 15자 이내로 작성하여야합니다');
+    }
   };
 
   return (
@@ -290,7 +299,7 @@ const CategoryPlaylist: React.FC<CategoryPlaylistProps> = ({ category: initialCa
               <input
                 type="text"
                 value={playlistNmae}
-                onChange={(e) => setPlayListName(e.target.value)}
+                onChange={onChangePlaylistName}
                 placeholder="재생목록 이름 입력"
                 onClick={(e) => e.stopPropagation()}
               />

--- a/front-end/src/components/playlist/TeacherPlaylist.tsx
+++ b/front-end/src/components/playlist/TeacherPlaylist.tsx
@@ -122,7 +122,7 @@ const TeacherPlaylist = () => {
       await addVideo(playlistName, selectedVideoIds, playlistId, token);
       alert('재생목록에 영상이 추가되었습니다');
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
     closeModal();
     setSelectedVideoIds('');
@@ -146,7 +146,7 @@ const TeacherPlaylist = () => {
       );
       alert('재생목록이 삭제 되었습니다');
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
     closeModal();
     setSelectedVideoIds('');

--- a/front-end/src/components/playlist/TeacherPlaylist.tsx
+++ b/front-end/src/components/playlist/TeacherPlaylist.tsx
@@ -26,6 +26,7 @@ const TeacherPlaylist = () => {
   const [showModal, setShowModal] = useState(false); // 모달 열림 상태
   const [selectedVideoIds, setSelectedVideoIds] = useState<string>(''); // 선택된 비디오 ID
   const [playlists, setPlaylists] = useState<PlayLists | undefined>(undefined); // 재생목록 상태
+  const maxLength = 15;
 
   // 선택된 강사가 변경될 때 URL 업데이트
   const handleTeacherSelect = (inst: (typeof instructorData)[number]) => {
@@ -56,6 +57,7 @@ const TeacherPlaylist = () => {
   const closeModal = () => {
     setShowModal(false); // 모달 닫기
     setPlayListName(''); // 입력 필드 초기화
+    setSelectedVideoIds('');
   };
 
   const toggleBottomBar = (index: number) => {
@@ -125,7 +127,6 @@ const TeacherPlaylist = () => {
       console.error(error);
     }
     closeModal();
-    setSelectedVideoIds('');
   };
 
   // 재생목록 삭제
@@ -149,7 +150,15 @@ const TeacherPlaylist = () => {
       console.error(error);
     }
     closeModal();
-    setSelectedVideoIds('');
+  };
+
+  const onChangePlaylistName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (value.length <= maxLength) {
+      setPlayListName(value);
+    } else {
+      alert('재생목록의 이름은 15자 이내로 작성하여야합니다');
+    }
   };
 
   const videos = selected.name === 'ALL' ? allQuery.data || [] : instQuery.data || [];
@@ -232,7 +241,7 @@ const TeacherPlaylist = () => {
               <input
                 type="text"
                 value={playlistName}
-                onChange={(e) => setPlayListName(e.target.value)}
+                onChange={onChangePlaylistName}
                 placeholder="재생목록 이름 입력"
                 onClick={(e) => e.stopPropagation()}
               />

--- a/front-end/src/styles/pages/chatbot/chatbot.scss
+++ b/front-end/src/styles/pages/chatbot/chatbot.scss
@@ -16,7 +16,7 @@
 }
 
 .chatbot-content_login {
-  width: 40vw;
+  width: 50rem;
   display: flex;
   flex-direction: row;
   position: fixed;
@@ -36,7 +36,7 @@
 
   textarea {
     width: 50%;
-    border: none;
+    border: 1px solid #c9c9c9;
     border-radius: 10px;
     min-width: 300px;
     min-height: 300px;
@@ -44,7 +44,6 @@
     padding: 10px;
     scrollbar-width: thin;
     scrollbar-color: var(--btn-color) #f1f1f1;
-    border: none;
     outline: none;
     color: var(--btn-color);
     :focus {
@@ -100,14 +99,13 @@
 
   div {
     background-color: var(--btn-color);
-    width: 100%;
     display: flex;
     justify-content: center;
     padding: 10px;
     border-radius: 10px;
     color: white;
     font-weight: 700;
-    min-width: 350px;
+    width: 38rem;
     .logout-link {
       color: rgb(255, 235, 59);
     }

--- a/front-end/src/styles/pages/my-video-list/my-video-list.scss
+++ b/front-end/src/styles/pages/my-video-list/my-video-list.scss
@@ -17,18 +17,21 @@
     font-size: 1.5rem;
   }
   .video-item {
+    border: 1px solid #ccc;
     width: 15vw;
-    height: 20vh;
+    min-height: 15rem;
     justify-content: center;
     align-items: center;
     background-color: var(--bg-color);
-    border-radius: 2rem;
-    padding: 15px;
+    border-radius: 1rem;
     cursor: pointer;
     box-sizing: border-box;
-    color: black;
-    transition: 1s;
+    transition: all 0.3s;
     margin-top: 10px;
+    color: #333;
+    font-size: 1.5rem;
+    font-weight: bold;
+    padding: 1rem 2rem;
     &:hover {
       transform: translateY(-10px);
     }
@@ -37,5 +40,7 @@
 
 .my-video-list-header {
   font-size: 4rem;
-  font-weight: 600;
+  font-weight: bold;
+  margin-top: 5rem;
+  margin-bottom: 3rem;
 }

--- a/front-end/src/styles/pages/mypage/mypage.scss
+++ b/front-end/src/styles/pages/mypage/mypage.scss
@@ -133,28 +133,37 @@
         font-size: 1.4rem;
       }
     }
+    .video-title {
+      font-size: 2rem;
+      font-weight: bold;
+    }
     .playlist-container {
       display: flex;
-      gap: 2rem;
       flex-wrap: wrap;
       overflow-y: auto;
       .playlist-item {
+        border: 1px solid #ccc;
         display: flex;
         flex-direction: column;
         width: 15vw;
-        align-items: center;
         background-color: var(--bg-color);
         color: black;
-        border-radius: 15px;
+        border-radius: 1rem;
         cursor: pointer;
-        transition: 1s;
+        transition: all 0.3s;
         gap: 1rem;
-        margin-top: 10px;
+        margin: 2rem 1rem 0;
+        padding: 1rem 2rem;
+        min-height: 15rem;
         .playlist-name {
           font-size: 1.8rem;
         }
         &:hover {
           transform: translateY(-10px);
+        }
+        h4 {
+          font-weight: bold;
+          margin-bottom: 1rem;
         }
       }
       a {


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 관련된 이슈 번호가 있으면 작성해주세요. -->
#176

## 📝 개요

.• 마이페이지 비디오란의 scss를 메모란과 동일하게 통일
.• 개발 중 제거하지 않은 console.log 제거
.• GPT 입력란의 보더값 추가 /  로그인 챗봇 위치 조정 / 챗봇 짤림 현상 수정
.• 이메일 비밀번호 오류 시 오류에 맞게 텍스트 반환 
• 재생목록 생성시 글자수를 15자로 제한

## 🛠️ 작업 내용

1. 기존의 마이페이지의 내 비디오 페이지와 내 메모 페이지의 스타일이 일치하지 않아 내 메모를 기준으로 내 비디오 페이지의 스타일을 수정하였습니다.
2. 개발 중 작성된 console.log를 제거 하였습니다.
3. GPT 입력란의 색상과 배경색이 동일하여 가시성이 떨어져 보더값을 추가하여 가시성을 올렸습니다. / 로그인시 챗봇의 입련란과 응답란의 위치를 수정하였습니다. / 화면 크기에 따라 챗봇이 짤리는 현상을 수정하였습니다.
4. 로그인시 이메일 / 비밀번호 오류시 그에 상응하는 텍스트를 반환하도록 수정하였습니다. 
5. 재생목록 생성시 최대 글자 수를 15자로 제한한였습니다

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
