### PR TITLE
[BE] 게시글 응답 DTO 수정 및 예외 처리

### DIFF
--- a/back-end/src/main/java/com/techie/backend/board/dto/PostResponse.java
+++ b/back-end/src/main/java/com/techie/backend/board/dto/PostResponse.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Data
 public class PostResponse {
+    private Long id;
     private String title;
     private String content;
     private PostCategory category;
@@ -22,5 +23,6 @@ public class PostResponse {
         this.writtenAt = post.getUpdatedAt();
         this.email = post.getUser().getEmail();
         this.nickname = post.getUser().getNickname();
+        this.id = post.getId();
     }
 }

--- a/back-end/src/main/java/com/techie/backend/board/service/PostService.java
+++ b/back-end/src/main/java/com/techie/backend/board/service/PostService.java
@@ -5,7 +5,6 @@ import com.techie.backend.board.domain.PostCategory;
 import com.techie.backend.board.dto.PostRequest;
 import com.techie.backend.board.dto.PostResponse;
 import com.techie.backend.board.repository.PostRepository;
-import com.techie.backend.global.exception.user.NoChangesException;
 import com.techie.backend.global.mapper.PostMapper;
 import com.techie.backend.global.security.UserDetailsCustom;
 import com.techie.backend.user.domain.User;
@@ -75,29 +74,33 @@ public class PostService {
         Post post = postRepository.findById(id).orElseThrow(()
                                             -> new EntityNotFoundException("게시글이 없습니다."));
         User user = userService.getUserFromSecurityContext(userDetails);
-
         validateOwner(user, post);
-
         postMapper.updateDto(updateRequest, post);
-        em.flush(); // 수정 사항 바로 반영
-
+        em.flush();
         return postMapper.toDto(post);
     }
 
 
     @Transactional
     public void deletePost(PostRequest.Delete delRequest, UserDetailsCustom userDetails) {
-        List<Long> postIds = delRequest.getPostIds();
-        if(postIds == null || postIds.isEmpty()) {
-            throw new NoChangesException();
-        }
         User user = userService.getUserFromSecurityContext(userDetails);
+        List<Long> postIds = delRequest.getPostIds();
+        if (postIds.isEmpty()) {
+            throw new EntityNotFoundException("삭제할 게시글이 없습니다.");
+        }
+
+        for(Long postId : postIds) {
+            Post post = postRepository.findById(postId).orElseThrow(()
+                    -> new EntityNotFoundException("존재하지 않는 게시글입니다." + "ID: " + postId));
+            validateOwner(user, post);
+        }
+
         postRepository.deleteAllByIds(postIds, user.getId());
     }
 
     private void validateOwner(User user, Post post) {
         if(!user.getId().equals(post.getUser().getId())) {
-            throw new AccessDeniedException("수정/삭제할 권한이 없습니다.");
+            throw new AccessDeniedException("수정/삭제할 권한이 없습니다." + "ID: " + post.getId());
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

## 📝 개요
게시글 응답 dto에 id 필드를 추가하고, 삭제 관련 예외처리를 보강하였습니다.

## 🛠️ 작업 내용
- PostResponse에 Long id 추가
- 자신의 게시글이 아니거나, 삭제할 게시글이 없다면 EntityNotFoundException 발생
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
